### PR TITLE
use avrogen fork

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/actgardner/gogen-avro/compiler"
-	"github.com/actgardner/gogen-avro/vm"
+	"github.com/rogpeppe/gogen-avro/v7/compiler"
+	"github.com/rogpeppe/gogen-avro/v7/vm"
 )
 
 type decodeProgram struct {

--- a/avro-generate-go/generate.go
+++ b/avro-generate-go/generate.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/actgardner/gogen-avro/parser"
-	"github.com/actgardner/gogen-avro/resolver"
-	"github.com/actgardner/gogen-avro/schema"
+	"github.com/rogpeppe/gogen-avro/v7/parser"
+	"github.com/rogpeppe/gogen-avro/v7/resolver"
+	"github.com/rogpeppe/gogen-avro/v7/schema"
 )
 
 func generate(w io.Writer, s []byte, pkg string) error {

--- a/avro-generate-go/template.go
+++ b/avro-generate-go/template.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/actgardner/gogen-avro/parser"
+	"github.com/rogpeppe/gogen-avro/v7/parser"
 )
 
 type templateParams struct {

--- a/decode.go
+++ b/decode.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/actgardner/gogen-avro/vm"
+	"github.com/rogpeppe/gogen-avro/v7/vm"
 )
 
 // Unmarshal unmarshals the given Avro-encoded binary data, which must

--- a/encode.go
+++ b/encode.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/actgardner/gogen-avro/schema"
+	"github.com/rogpeppe/gogen-avro/v7/schema"
 )
 
 // Set to true for deterministic output.

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/heetch/avro
 go 1.14
 
 require (
-	github.com/actgardner/gogen-avro v6.3.2-0.20191230211803-dfccd5d39401+incompatible
 	github.com/frankban/quicktest v1.7.2
 	github.com/kr/pretty v0.1.0
 	github.com/linkedin/goavro/v2 v2.9.7
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/rogpeppe/gogen-avro/v7 v7.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,4 @@
-github.com/actgardner/gogen-avro v6.3.2-0.20191230211803-dfccd5d39401+incompatible h1:571aT88xvQovO7vm7t8GT2QTuv3eTusDZSx2faPw5Bg=
-github.com/actgardner/gogen-avro v6.3.2-0.20191230211803-dfccd5d39401+incompatible/go.mod h1:N2PzqZtS+5w9xxGp2daeykhWdTL0lBiRhbbvkVj4Yd8=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.7.2 h1:2QxQoC1TS09S7fhCPsrvqYdvP1H5M1P1ih5ABm3BTYk=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
@@ -17,10 +14,6 @@ github.com/linkedin/goavro/v2 v2.9.7 h1:Vd++Rb/RKcmNJjM0HP/JJFMEWa21eUBVKPYlKehO
 github.com/linkedin/goavro/v2 v2.9.7/go.mod h1:UgQUb2N/pmueQYH9bfqFioWxzYCZXSfF8Jw03O5sjqA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+github.com/rogpeppe/gogen-avro/v7 v7.0.0 h1:NQVRmrqbeCwSE5upW1XJOqov3yW5O6y0lQytCwTOqzQ=
+github.com/rogpeppe/gogen-avro/v7 v7.0.0/go.mod h1:awhtQwpFg18PdUpdnOFr0ceVLYAn/oDCa/HE1hdbk50=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/gotype.go
+++ b/gotype.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/actgardner/gogen-avro/schema"
+	"github.com/rogpeppe/gogen-avro/v7/schema"
 
 	"github.com/heetch/avro/avrotypegen"
 )

--- a/type.go
+++ b/type.go
@@ -3,9 +3,9 @@ package avro
 import (
 	"fmt"
 
-	"github.com/actgardner/gogen-avro/parser"
-	"github.com/actgardner/gogen-avro/resolver"
-	"github.com/actgardner/gogen-avro/schema"
+	"github.com/rogpeppe/gogen-avro/v7/parser"
+	"github.com/rogpeppe/gogen-avro/v7/resolver"
+	"github.com/rogpeppe/gogen-avro/v7/schema"
 )
 
 // Type represents an Avro schema type.


### PR DESCRIPTION
[This issue](https://github.com/actgardner/gogen-avro/issues/119) makes it hard to use avrogen the way we want to, and it's not clear how long it might take to merge the fix, so for the time being let's use a forked version.

The module involved isn't exposed at all in the public API so this is a backwardly compatible change, and it'll be backwardly compatible to revert it too.