### PR TITLE
namespace support

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -62,9 +62,9 @@ type pathElem struct {
 
 // compileDecoder returns a decoder program to decode into values of the given type
 // Avro values encoded with the given writer schema.
-func compileDecoder(t reflect.Type, writerType *Type) (*decodeProgram, error) {
+func compileDecoder(names *Names, t reflect.Type, writerType *Type) (*decodeProgram, error) {
 	// First determine the schema for the type.
-	readerType, err := avroTypeOf(t)
+	readerType, err := avroTypeOf(names, t)
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine schema for %s: %v", t, err)
 	}

--- a/decode.go
+++ b/decode.go
@@ -20,12 +20,18 @@ import (
 //
 // Unmarshal returns the reader type.
 func Unmarshal(data []byte, x interface{}, wType *Type) (*Type, error) {
+	return globalNames.Unmarshal(data, x, wType)
+}
+
+// Unmarshal is like the Unmarshal function except that names
+// in the schema for x are renamed according to names.
+func (names *Names) Unmarshal(data []byte, x interface{}, wType *Type) (*Type, error) {
 	v := reflect.ValueOf(x)
 	t := v.Type()
 	if t.Kind() != reflect.Ptr {
 		return nil, fmt.Errorf("destination is not a pointer %s", t)
 	}
-	prog, err := compileDecoder(t.Elem(), wType)
+	prog, err := compileDecoder(names, t.Elem(), wType)
 	if err != nil {
 		return nil, err
 	}

--- a/names.go
+++ b/names.go
@@ -1,0 +1,221 @@
+package avro
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/rogpeppe/gogen-avro/v7/parser"
+	"github.com/rogpeppe/gogen-avro/v7/schema"
+)
+
+// Names represents a namespace that can rename schema names.
+// The zero value of a Names is the empty namespace.
+type Names struct {
+	// renames maps from an original Avro schema fully qualified
+	// name to the new name and aliases for that name.
+	renames map[string][]string
+
+	// avroTypes is effectively a map[reflect.Type]*Type
+	// that holds Avro types for Go types that specify the schema
+	// entirely. Go types that don't fully specify a schema must be resolved
+	// with respect to a given writer schema and so cannot live in
+	// here.
+	//
+	// If there's an error translating a type, it's stored here as
+	// an errorSchema.
+	goTypeToAvroType sync.Map
+	goTypeToEncoder  sync.Map
+}
+
+var builtinTypes = map[string]bool{
+	"int":     true,
+	"long":    true,
+	"string":  true,
+	"bytes":   true,
+	"float":   true,
+	"double":  true,
+	"boolean": true,
+	"null":    true,
+}
+
+// Rename returns a copy of n that renames oldName to newName
+// with the given aliases when a schema is used.
+//
+// If aliases aren't full names, their namespace will be taken from
+// the namespace of newName.
+//
+// If n already includes a rename for oldName, the old association
+// will be overwritten.
+//
+// The rename only applies to schemas directly - it does not rename
+// names already passed to Rename as newName or aliases.
+//
+// So for example:
+//
+//	n.Rename("foo", "bar").
+//		Rename("bar", "baz").
+//		TypeOf(`{"type":"record", "name": "foo", "fields": ...}`)
+//
+// will return a type with a schema named "bar", not "baz".
+//
+// Rename panics if oldName is any of the built-in Avro types.
+func (n *Names) Rename(oldName string, newName string, newAliases ...string) *Names {
+	if builtinTypes[oldName] {
+		panic(fmt.Errorf("rename of built-in type %q to %q", oldName, newName))
+	}
+	n1 := &Names{
+		renames: make(map[string][]string),
+	}
+	for name, names := range n.renames {
+		n1.renames[name] = names
+	}
+	newNames := make([]string, 1+len(newAliases))
+	newNames[0] = newName
+	copy(newNames[1:], newAliases)
+	n1.renames[oldName] = newNames
+	return n1
+}
+
+// RenameType returns a copy of n that uses the given name
+// and aliases for the type of x.
+//
+// RenameType will panic if TypeOf(x) returns an error or the type doesn't
+// represent an Avro named definition (a record, an enum or a fixed Avro type)
+//
+// If RenameType has already been called for the type of x, the old association will be
+// overwritten.
+func (n *Names) RenameType(x interface{}, newName string, newAliases ...string) *Names {
+	// TODO on the errors below, we could just ignore the Add and return n unchanged.
+	// The caller will get an error if they ever try to use the type
+	// for encoding or decoding, so maybe that's OK.
+	t, err := TypeOf(x)
+	if err != nil {
+		panic(fmt.Errorf("cannot rename %T to %q: cannot get Avro type: %v", x, newName, err))
+	}
+	name := t.name()
+	if name == "" {
+		panic(fmt.Errorf("cannot rename %T to %q: it does not represent an Avro definition", x, newName))
+	}
+	return n.Rename(name, newName, newAliases...)
+}
+
+// TypeOf is like the TypeOf function except that Avro names
+// in x will be translate through the namespace n.
+func (n *Names) TypeOf(x interface{}) (*Type, error) {
+	return avroTypeOf(n, reflect.TypeOf(x))
+}
+
+func (names *Names) renameSchema(at schema.AvroType) interface{} {
+	return names.renameSchema1(at, "", make(map[schema.QualifiedName]bool))
+}
+
+func (names *Names) renameSchema1(at schema.AvroType, enclosingNamespace string, defined map[schema.QualifiedName]bool) interface{} {
+	switch at := at.(type) {
+	case *schema.Reference:
+		// https://avro.apache.org/docs/1.9.1/spec.html#Aliases
+		// "A type alias may be specified either as fully
+		// namespace-qualified, or relative to the namespace of
+		// the name it is an alias for."
+		var qname schema.QualifiedName
+		var qaliases []schema.QualifiedName
+		if newNames, ok := names.renames[at.TypeName.String()]; ok {
+			qname = parser.ParseAvroName("", newNames[0])
+			qaliases = make([]schema.QualifiedName, len(newNames)-1)
+			for i, alias := range newNames[1:] {
+				qaliases[i] = parser.ParseAvroName(qname.Namespace, alias)
+			}
+		} else {
+			qname = at.TypeName
+			qaliases = at.Def.Aliases()
+		}
+		if defined[qname] {
+			// It's a reference to a type that's already been
+			// defined, so just use the new name.
+			return relativeName(enclosingNamespace, qname)
+		}
+		// References are always represented by a JSON object
+		// (a map in Go).
+		def := copyOfSchemaObj(at)
+		defined[qname] = true
+		switch adef := at.Def.(type) {
+		case *schema.RecordDefinition:
+			fieldDefs := make([]map[string]interface{}, len(adef.Fields()))
+			for i, f := range adef.Fields() {
+				fieldDef := copyOfSchemaObj(f)
+				fieldDef["type"] = names.renameSchema1(f.Type(), qname.Namespace, defined)
+				fieldDefs[i] = fieldDef
+			}
+			def["fields"] = fieldDefs
+		case *schema.FixedDefinition:
+		case *schema.EnumDefinition:
+		default:
+			panic(fmt.Errorf("unknown definition type %T", adef))
+		}
+		delete(def, "namespace")
+		def["name"] = relativeName(enclosingNamespace, qname)
+		delete(def, "aliases")
+		if len(qaliases) > 0 {
+			aliases := make([]string, len(qaliases))
+			for i, name := range qaliases {
+				aliases[i] = relativeName(qname.Namespace, name)
+			}
+			def["aliases"] = aliases
+		}
+		return def
+	case *schema.UnionField:
+		items := make([]interface{}, len(at.ItemTypes()))
+		for i, item := range at.ItemTypes() {
+			items[i] = names.renameSchema1(item, enclosingNamespace, defined)
+		}
+		return items
+	case *schema.ArrayField:
+		obj := copyOfSchemaObj(at)
+		obj["items"] = names.renameSchema1(at.ItemType(), enclosingNamespace, defined)
+		return obj
+	case *schema.MapField:
+		obj := copyOfSchemaObj(at)
+		obj["values"] = names.renameSchema1(at.ItemType(), enclosingNamespace, defined)
+		return obj
+	default:
+		obj, _ := at.Definition(emptyScope())
+		return obj
+	}
+}
+
+func relativeName(enclosingNamespace string, name schema.QualifiedName) string {
+	if name.Namespace == enclosingNamespace {
+		return name.Name
+	}
+	return name.String()
+}
+
+type avroDefinitioner interface {
+	Definition(map[schema.QualifiedName]interface{}) (interface{}, error)
+}
+
+func copyOfSchemaObj(at interface{}) map[string]interface{} {
+	var obj interface{}
+	// Note: at the time of writing there's no way that Definition can
+	// return an error.
+	switch at := at.(type) {
+	case *schema.Field:
+		obj, _ = at.Definition(emptyScope())
+	case schema.AvroType:
+		obj, _ = at.Definition(emptyScope())
+	}
+	switch obj := obj.(type) {
+	case map[string]interface{}:
+		obj1 := make(map[string]interface{})
+		for name, val := range obj {
+			obj1[name] = val
+		}
+		return obj1
+	default:
+		panic(fmt.Errorf("unexpected type for Avro definition %T", obj))
+	}
+}
+
+func emptyScope() map[schema.QualifiedName]interface{} {
+	return make(map[schema.QualifiedName]interface{})
+}

--- a/names_test.go
+++ b/names_test.go
@@ -1,0 +1,344 @@
+package avro_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/heetch/avro"
+	"github.com/heetch/avro/internal/testtypes"
+)
+
+func TestNamesRenameType(t *testing.T) {
+	type S struct {
+		A int
+	}
+	type T struct {
+		S1 S
+		S2 S
+	}
+	type W struct {
+		E testtypes.Enum
+		F [2]byte
+		M map[string]*S
+		R []TestRecord
+		I int
+	}
+	tests := []struct {
+		testName     string
+		oldNames     []string
+		newNames     []string
+		newAliases   [][]string
+		val          interface{}
+		expectSchema string
+	}{{
+		testName: "go-type",
+		oldNames: []string{"S"},
+		newNames: []string{"foo"},
+		val:      S{},
+		expectSchema: `{
+			"type": "record",
+			"name": "foo",
+			"fields": [{
+				"name": "A",
+				"type": "long",
+				"default": 0
+			}]
+		}`,
+	}, {
+		testName: "generated-type",
+		oldNames: []string{"TestRecord"},
+		newNames: []string{"foo"},
+		val:      TestRecord{},
+		expectSchema: `{
+			"name": "foo",
+			"type": "record",
+			"fields": [{
+				"default": 42,
+				"name": "A",
+				"type": {
+					"type": "int"
+				}
+			}, {
+				"name": "B",
+				"type": {
+					"type": "int"
+				}
+			}]
+		}`,
+	}, {
+		testName: "multiple-occurrences-of-renamed-type",
+		oldNames: []string{"S"},
+		newNames: []string{"bar"},
+		val:      T{},
+		expectSchema: `{
+			"name": "T",
+			"type": "record",
+			"fields": [{
+				"name": "S1",
+				"default": {"A": 0},
+				"type": {
+					"type": "record",
+					"name": "bar",
+					"fields": [{
+						"name": "A",
+						"default": 0,
+						"type": "long"
+					}]
+				}
+			}, {
+				"name": "S2",
+				"default": {"A": 0},
+				"type": "bar"
+			}]
+		}`,
+	}, {
+		testName: "multiple-renames",
+		oldNames: []string{"S", "T"},
+		newNames: []string{"newS", "newT"},
+		val:      T{},
+		expectSchema: `{
+			"name": "newT",
+			"type": "record",
+			"fields": [{
+				"name": "S1",
+				"default": {"A": 0},
+				"type": {
+					"type": "record",
+					"name": "newS",
+					"fields": [{
+						"name": "A",
+						"default": 0,
+						"type": "long"
+					}]
+				}
+			}, {
+				"name": "S2",
+				"default": {"A": 0},
+				"type": "newS"
+			}]
+		}`,
+	}, {
+		testName: "swap-names",
+		oldNames: []string{"S", "T"},
+		newNames: []string{"T", "S"},
+		val:      T{},
+		expectSchema: `{
+			"name": "S",
+			"type": "record",
+			"fields": [{
+				"name": "S1",
+				"default": {"A": 0},
+				"type": {
+					"type": "record",
+					"name": "T",
+					"fields": [{
+						"name": "A",
+						"default": 0,
+						"type": "long"
+					}]
+				}
+			}, {
+				"name": "S2",
+				"default": {"A": 0},
+				"type": "T"
+			}]
+		}`,
+	}, {
+		testName: "different-types",
+		oldNames: []string{"W", "Enum", "go.Fixed2", "S", "TestRecord", "T", "S"},
+		newNames: []string{"newW", "newEnum", "myFixed", "newS", "newTestRecord", "newT", "newS"},
+		val:      W{},
+		expectSchema: `{
+			"name": "newW",
+			"type": "record",
+			"fields": [{
+				"name": "E",
+				"default": "One",
+				"type": {
+					"type": "enum",
+					"name": "newEnum",
+					"symbols": ["One", "Two", "Three"]
+				}
+			}, {
+				"name": "F",
+				"default": "\u0000\u0000",
+				"type": {
+					"type": "fixed",
+					"name": "myFixed",
+					"size": 2
+				}
+			}, {
+				"name": "M",
+				"default": {},
+				"type": {
+					"type": "map",
+					"values": [
+						"null",
+						{
+							"type": "record",
+							"name": "newS",
+							"fields": [{
+								"name": "A",
+								"type": "long",
+								"default": 0
+							}]
+						}
+					]
+				}
+			}, {
+				"name": "R",
+				"default": [],
+				"type": {
+					"type": "array",
+					"items": {
+						"name": "newTestRecord",
+						"type": "record",
+						"fields": [{
+							"default": 42,
+							"name": "A",
+							"type": {
+								"type": "int"
+							}
+						}, {
+							"name": "B",
+							"type": {
+								"type": "int"
+							}
+						}]
+					}
+				}
+			}, {
+				"name": "I",
+				"default": 0,
+				"type": "long"
+			}]
+		}`,
+	}, {
+		testName: "relative-namespace",
+		oldNames: []string{"S", "T"},
+		newNames: []string{"a.newS", "a.newT"},
+		val:      T{},
+		expectSchema: `{
+			"name": "a.newT",
+			"type": "record",
+			"fields": [{
+				"name": "S1",
+				"default": {"A": 0},
+				"type": {
+					"type": "record",
+					"name": "newS",
+					"fields": [{
+						"name": "A",
+						"default": 0,
+						"type": "long"
+					}]
+				}
+			}, {
+				"name": "S2",
+				"default": {"A": 0},
+				"type": "newS"
+			}]
+		}`,
+	}, {
+		testName: "non-relative-namespace",
+		oldNames: []string{"S", "T"},
+		newNames: []string{"a.newS", "b.newT"},
+		val:      T{},
+		expectSchema: `{
+			"name": "b.newT",
+			"type": "record",
+			"fields": [{
+				"name": "S1",
+				"default": {"A": 0},
+				"type": {
+					"type": "record",
+					"name": "a.newS",
+					"fields": [{
+						"name": "A",
+						"default": 0,
+						"type": "long"
+					}]
+				}
+			}, {
+				"name": "S2",
+				"default": {"A": 0},
+				"type": "a.newS"
+			}]
+		}`,
+	}, {
+		testName:   "relative-alias-namespace",
+		oldNames:   []string{"S"},
+		newNames:   []string{"a.newS"},
+		newAliases: [][]string{{"a.alias1", "b.alias2", "c.d.alias3"}},
+		val:        S{},
+		expectSchema: `{
+			"type": "record",
+			"name": "a.newS",
+			"aliases": ["alias1", "b.alias2", "c.d.alias3"],
+			"fields": [{
+				"name": "A",
+				"type": "long",
+				"default": 0
+			}]
+		}`,
+	}}
+
+	c := qt.New(t)
+	for _, test := range tests {
+		c.Run(test.testName, func(c *qt.C) {
+			names := new(avro.Names)
+			for i, oldName := range test.oldNames {
+				var aliases []string
+				if i < len(test.newAliases) {
+					aliases = test.newAliases[i]
+				}
+				names = names.Rename(oldName, test.newNames[i], aliases...)
+			}
+			at, err := names.TypeOf(test.val)
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(at.String(), qt.JSONEquals, json.RawMessage(test.expectSchema))
+		})
+	}
+}
+
+func TestRenameBuiltinAvroTypePanics(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(func() {
+		new(avro.Names).Rename("int", "evil")
+	}, qt.PanicMatches, `rename of built-in type "int" to "evil"`)
+}
+
+func TestRenameTypeSuccess(t *testing.T) {
+	type S struct {
+		A int
+	}
+	c := qt.New(t)
+	names := new(avro.Names).RenameType(S{}, "newS")
+	at, err := names.TypeOf(S{})
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(at.String(), qt.JSONEquals, json.RawMessage(`{
+		"type": "record",
+		"name": "newS",
+		"fields": [{
+			"name": "A",
+			"type": "long",
+			"default": 0
+		}]
+	}`))
+}
+
+func TestRenameTypeBadType(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(func() {
+		new(avro.Names).RenameType(struct{}{}, "empty")
+	}, qt.PanicMatches, `cannot rename struct {} to "empty": cannot get Avro type: cannot use unnamed type struct {} as Avro type`)
+}
+
+func TestRenameTypeNonDefinition(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(func() {
+		new(avro.Names).RenameType("", "myString")
+	}, qt.PanicMatches, `cannot rename string to "myString": it does not represent an Avro definition`)
+}

--- a/singledecoder_test.go
+++ b/singledecoder_test.go
@@ -60,7 +60,7 @@ func TestSingleDecoder(t *testing.T) {
 		}
 	}]
 }`,
-	})
+	}, nil)
 	data, _, err := avro.Marshal(TestRecord{A: 40, B: 20})
 	c.Assert(err, qt.Equals, nil)
 	c.Logf("data: %d", data)

--- a/singleencoder_test.go
+++ b/singleencoder_test.go
@@ -16,14 +16,14 @@ func TestSingleEncoder(t *testing.T) {
 	registry := memRegistry{
 		1: avroType.String(),
 	}
-	enc := avro.NewSingleEncoder(registry)
+	enc := avro.NewSingleEncoder(registry, nil)
 	data, err := enc.Marshal(context.Background(), TestRecord{A: 20, B: 34})
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(data, qt.DeepEquals, []byte{1, 40, 68})
 
 	// Check that we can decode it again.
 	var x TestRecord
-	dec := avro.NewSingleDecoder(registry)
+	dec := avro.NewSingleDecoder(registry, nil)
 	_, err = dec.Unmarshal(context.Background(), data, &x)
 	c.Assert(err, qt.Equals, nil)
 	c.Assert(x, qt.DeepEquals, TestRecord{A: 20, B: 34})

--- a/type.go
+++ b/type.go
@@ -24,7 +24,7 @@ func ParseType(s string) (*Type, error) {
 	}
 	for _, def := range ns.Roots {
 		if err := resolver.ResolveDefinition(def, ns.Definitions); err != nil {
-			return nil, fmt.Errorf("cannot resolve references in schema: %v", err)
+			return nil, fmt.Errorf("cannot resolve references in schema\n%s\n: %v", s, err)
 		}
 	}
 	return &Type{
@@ -35,4 +35,14 @@ func ParseType(s string) (*Type, error) {
 
 func (t *Type) String() string {
 	return t.schema
+}
+
+// name returns the fully qualified Avro name for the type,
+// or the empty string if it's not a definition.
+func (t *Type) name() string {
+	ref, ok := t.avroType.(*schema.Reference)
+	if !ok {
+		return ""
+	}
+	return ref.TypeName.String()
 }


### PR DESCRIPTION
This adds the capability to change the names in Avro schemas.
This can be used to change the automatically assigned names
given to schemas derived from Go types, for example.