### PR TITLE
support external verification of round trip tests

### DIFF
--- a/avro-generate-go/internal/avrotestdata/testdata.go
+++ b/avro-generate-go/internal/avrotestdata/testdata.go
@@ -1,0 +1,46 @@
+package avrotestdata
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type Test struct {
+	TestName      string             `json:"testName"`
+	InSchema      json.RawMessage    `json:"inSchema"`
+	OutSchema     json.RawMessage    `json:"outSchema"`
+	GoType        string             `json:"goType"`
+	GoTypeBody    string             `json:"goTypeBody"`
+	GenerateError string             `json:"generateError"`
+	Subtests      map[string]Subtest `json:"subtests"`
+}
+
+type Subtest struct {
+	TestName    string            `json:"testName"`
+	InData      json.RawMessage   `json:"inData"`
+	OutData     json.RawMessage   `json:"outData"`
+	ExpectError map[string]string `json:"expectError"`
+}
+
+func Load(dir string) (map[string]Test, error) {
+	var buf bytes.Buffer
+	cmd := exec.Command("cue", "export")
+	cmd.Dir = dir
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = &buf
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("cue export failed: %v", err)
+	}
+	var exported struct {
+		Tests map[string]Test `json:"tests"`
+	}
+	err = json.Unmarshal(buf.Bytes(), &exported)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal test data: %v", err)
+	}
+	return exported.Tests, nil
+}

--- a/avro-generate-go/testdata/cloudevent.cue
+++ b/avro-generate-go/testdata/cloudevent.cue
@@ -31,7 +31,7 @@ tests: cloudEvent: {
 	outSchema: {
 		name:      "SomeEvent"
 		namespace: "bar"
-		type: "record"
+		type:      "record"
 		fields: [{
 			name: "Metadata"
 			type: {

--- a/avro-generate-go/testdata/default.cue
+++ b/avro-generate-go/testdata/default.cue
@@ -1,5 +1,7 @@
 package roundtrip
 
+// Some implementations don't like records with no fields in,
+// so we'll use a record with one arbitrary field instead.
 emptyRecord :: {
 	type: "record"
 	name: string
@@ -9,6 +11,8 @@ emptyRecord :: {
 		default: 0
 	}]
 }
+
+emptyRecordData :: "_": 0
 
 tests: primitiveDefaults: {
 	inSchema: emptyRecord
@@ -42,7 +46,7 @@ tests: primitiveDefaults: {
 			default: true
 		}]
 	}
-	inData: {}
+	inData: emptyRecordData
 	outData: {
 		int:     1111
 		long:    2222
@@ -68,7 +72,7 @@ tests: arrayDefault: {
 			default: [2, 3, 4]
 		}]
 	}
-	inData: {}
+	inData: emptyRecordData
 	outData: arrayOfInt: [2, 3, 4]
 }
 
@@ -91,7 +95,7 @@ tests: mapDefault: {
 			}
 		}]
 	}
-	inData: {}
+	inData: emptyRecordData
 	outData: mapOfInt: {
 		a: 2
 		b: 5
@@ -128,7 +132,7 @@ tests: recordDefault: {
 			}
 		}]
 	}
-	inData: {}
+	inData: emptyRecordData
 	outData: recordField: {
 		F1: 44
 		F2: "whee"
@@ -152,7 +156,7 @@ tests: enumDefault: {
 			default: "b"
 		}]
 	}
-	inData: {}
+	inData: emptyRecordData
 	outData: enumField: "b"
 }
 
@@ -172,6 +176,6 @@ tests: fixedDefault: {
 			default: "hello"
 		}]
 	}
-	inData: {}
+	inData: emptyRecordData
 	outData: fixedField: "hello"
 }

--- a/avro-generate-go/testdata/gotype.cue
+++ b/avro-generate-go/testdata/gotype.cue
@@ -26,7 +26,6 @@ tests: goTypeMultipleFields: {
 	outData: inData
 }
 
-
 tests: goTypePointer: {
 	inSchema: {
 		name: "R"

--- a/avro-generate-go/testdata/logicaltype.cue
+++ b/avro-generate-go/testdata/logicaltype.cue
@@ -7,12 +7,12 @@ tests: timestampMicros: {
 		fields: [{
 			name: "T"
 			type: {
-				type: "long"
+				type:        "long"
 				logicalType: "timestamp-micros"
 			}
 		}]
 	}
-	outSchema: inSchema,
+	outSchema: inSchema
 	inData: T: 1579176162000001
 	outData: inData
 }

--- a/avro-generate-go/testdata/record.cue
+++ b/avro-generate-go/testdata/record.cue
@@ -1,27 +1,5 @@
 package roundtrip
 
-tests: recordWithDefaultNotPresent: {
-	inSchema: {
-		type: "record"
-		name: "R"
-		fields: [{
-			name: "A"
-			type: "int"
-			default: 99
-		}]
-	}
-	outSchema: {
-		type: "record"
-		name: "R"
-		fields: [{
-			name: "A"
-			type: "int"
-		}]
-	}
-	inData: {}
-	outData: A: 99
-}
-
 tests: largeRecord: {
 	inSchema: {
 		type:      "record"
@@ -158,13 +136,13 @@ tests: largeRecord: {
 	}
 	goType:    "Sample"
 	outSchema: inSchema
-	inData: header: "headerworks.Data0": hostname: string: "myhost.com"
-	outData: {
-		body: null
+	inData: {
 		header: "headerworks.Data0": {
 			hostname: string: "myhost.com"
 			trace: null
 			uuid:  null
 		}
+		body: null
 	}
+	outData: inData
 }

--- a/avro-generate-go/testdata/testschema.cue
+++ b/avro-generate-go/testdata/testschema.cue
@@ -17,8 +17,8 @@ roundTripTest :: {
 	// generateError holds the error expected from invoking avro-generate-go.
 	// If this is specified, there will be no generated test package.
 	generateError?: string
-	inData?:     _
-	outData?:    _
+	inData?:        _
+	outData?:       _
 	expectError?: [errorKind]: string
 	subtests: [name=_]: {
 		testName: name

--- a/avro-generate-go/testdata/union.cue
+++ b/avro-generate-go/testdata/union.cue
@@ -91,7 +91,7 @@ tests: unionIntVsLong: {
 			default: 1234
 		}]
 	}
-	inData: F: int: 999
+	inData: F: int:   999
 	outData: F: long: 999
 }
 

--- a/avro-generate-go/verify_test.go
+++ b/avro-generate-go/verify_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/heetch/avro/avro-generate-go/internal/avrotestdata"
+)
+
+// Note: external command is called with three args:
+//	in-schema, in-data, out-schema, all in JSON format
+// It's expected to produce JSON output with the round-tripped data.
+
+func TestExternalVerify(t *testing.T) {
+	c := qt.New(t)
+	verifyCmd := os.Getenv("AVRO_VERIFY")
+	if verifyCmd == "" {
+		c.Skip("$AVRO_VERIFY not set")
+	}
+	tests, err := avrotestdata.Load("./testdata")
+	c.Assert(err, qt.Equals, nil)
+	// Run tests in deterministic order by sorting keys.
+	for _, test := range tests {
+		test := test
+		c.Run(test.TestName, func(c *qt.C) {
+			if test.GoTypeBody != "" {
+				c.Skip("test uses GoTypeBody")
+			}
+			if test.GenerateError != "" {
+				c.Skip("test uses GenerateError")
+			}
+			inSchema := jsonMarshal(test.InSchema)
+			outSchema := jsonMarshal(test.OutSchema)
+			for _, subtest := range test.Subtests {
+				subtest := subtest
+				c.Run(subtest.TestName, func(c *qt.C) {
+					if subtest.ExpectError != nil {
+						c.Skip("subtest uses ExpectError")
+					}
+					inData := jsonMarshal(subtest.InData)
+					c.Logf("run %s '%s' '%s' '%s'", verifyCmd, inSchema, outSchema, inData)
+					cmd := exec.Command(verifyCmd, inSchema, outSchema, inData)
+					var stdout, stderr bytes.Buffer
+					cmd.Stdout = &stdout
+					cmd.Stderr = &stderr
+					err := cmd.Run()
+					c.Assert(err, qt.Equals, nil, qt.Commentf("stderr:\n%s", &stderr))
+					c.Assert(stdout.Bytes(), qt.JSONEquals, subtest.OutData)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows us to verify the Go Avro behaviour against
the canonical Java implementation (and potentially other
implementations too).

We fix the tests that require fixing because of this.

The script I've been using for AVRO_VERIFY is this:

	#!/usr/bin/env rc

	if(! ~ $#* 3) {
		echo usage: avroverify in-schema out-schema in-data >[1=2]
		exit 1
	}
	inSchema=$1
	outSchema=$2
	inData=$3
	dir=`{mktemp -d}
	if (! echo $inData | avro fromjson --schema $inSchema - > $dir/data.out) {
		echo fromjson failed >[1=2]
		exit 1
	}
	if (! avro tojson --reader-schema $outSchema $dir/data.out) {
		echo tojson failed >[1=2]
		exit 1
	}
	rm -r $dir

where the `avro` command is itself a wrapper around the `avro-tools.jar` file:

	java \
		'-Dlog4j.configuration=file://'^<{echo 'log4j.rootLogger=off'} \
		--add-opens 'java.security.jgss/sun.security.krb5=ALL-UNNAMED' \
		-jar $AVRO_TOOLS_JAR $*

Note: the script above relies on functionality not yet available in `avro-tools` until https://github.com/apache/avro/pull/785 lands.