### PR TITLE
cmd/avro-generate-go: implement String etc methods for enums

### DIFF
--- a/cmd/avro-generate-go/generatetestcode.go
+++ b/cmd/avro-generate-go/generatetestcode.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/format"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -116,6 +117,9 @@ func main() {
 				check("remove dir", err)
 				continue
 			}
+			if err != nil {
+				io.Copy(os.Stderr, &buf)
+			}
 			check("avro-generate-go "+file, err)
 		} else {
 			// The Go tool seems to require at least some
@@ -135,6 +139,12 @@ func main() {
 		check("write test go file", err)
 		if fmtErr != nil {
 			check("gofmt test code "+outFile, fmtErr)
+		}
+		if test.OtherTests != "" {
+			otherTest, err := format.Source([]byte(test.OtherTests))
+			check("format other tests", err)
+			err = ioutil.WriteFile(filepath.Join(dir, "other_test.go"), otherTest, 0666)
+			check("write other tests", err)
 		}
 	}
 	if failed {

--- a/cmd/avro-generate-go/internal/avrotestdata/testdata.go
+++ b/cmd/avro-generate-go/internal/avrotestdata/testdata.go
@@ -16,6 +16,7 @@ type Test struct {
 	GoTypeBody    string             `json:"goTypeBody"`
 	GenerateError string             `json:"generateError"`
 	Subtests      map[string]Subtest `json:"subtests"`
+	OtherTests    string             `json:"otherTests"`
 }
 
 type Subtest struct {

--- a/cmd/avro-generate-go/internal/generated_tests/enumDefault/schema_gen.go
+++ b/cmd/avro-generate-go/internal/generated_tests/enumDefault/schema_gen.go
@@ -3,7 +3,9 @@
 package enumDefault
 
 import (
+	"fmt"
 	"github.com/heetch/avro/avrotypegen"
+	"strconv"
 )
 
 type Foo int
@@ -14,7 +16,41 @@ const (
 	FooC
 )
 
-// TODO UnmarshalText and String methods.
+var _Foo_strings = []string{
+	"a",
+	"b",
+	"c",
+}
+
+// String returns the textual representation of Foo.
+func (e Foo) String() string {
+	if e < 0 || int(e) >= len(_Foo_strings) {
+		return "Foo(" + strconv.FormatInt(int64(e), 10) + ")"
+	}
+	return _Foo_strings[e]
+}
+
+// MarshalText implements encoding.TextMarshaler
+// by returning the textual representation of Foo.
+func (e Foo) MarshalText() ([]byte, error) {
+	if e < 0 || int(e) >= len(_Foo_strings) {
+		return nil, fmt.Errorf("Foo value %d is out of bounds", e)
+	}
+	return []byte(_Foo_strings[e]), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler
+// by expecting the textual representation of Foo.
+func (e *Foo) UnmarshalText(data []byte) error {
+	// Note for future: this could be more efficient.
+	for i, s := range _Foo_strings {
+		if string(data) == s {
+			*e = Foo(i)
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown value %q for Foo", data)
+}
 
 type R struct {
 	EnumField Foo `json:"enumField"`

--- a/cmd/avro-generate-go/internal/generated_tests/simpleEnum/other_test.go
+++ b/cmd/avro-generate-go/internal/generated_tests/simpleEnum/other_test.go
@@ -1,0 +1,63 @@
+package simpleEnum
+
+import (
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/heetch/avro"
+)
+
+func TestString(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(MyEnumA.String(), qt.Equals, "a")
+	c.Assert(MyEnumB.String(), qt.Equals, "b")
+	c.Assert(MyEnumC.String(), qt.Equals, "c")
+	c.Assert(MyEnum(-1).String(), qt.Equals, "MyEnum(-1)")
+	c.Assert(MyEnum(3).String(), qt.Equals, "MyEnum(3)")
+}
+
+func TestMarshalText(t *testing.T) {
+	c := qt.New(t)
+	data, err := MyEnumA.MarshalText()
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(string(data), qt.Equals, "a")
+
+	data, err = MyEnum(-1).MarshalText()
+	c.Assert(err, qt.ErrorMatches, `MyEnum value -1 is out of bounds`)
+
+	data, err = MyEnum(3).MarshalText()
+	c.Assert(err, qt.ErrorMatches, `MyEnum value 3 is out of bounds`)
+}
+
+func TestUnmarshalText(t *testing.T) {
+	c := qt.New(t)
+	var e MyEnum
+	err := e.UnmarshalText([]byte("b"))
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(e, qt.Equals, MyEnumB)
+
+	// Check that it works OK with encoding/json too.
+	var x struct {
+		E MyEnum
+	}
+	err = json.Unmarshal([]byte(`{"E": "c"}`), &x)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(x.E, qt.Equals, MyEnumC)
+
+	x.E = 0
+	err = json.Unmarshal([]byte(`{"E": "unknown"}`), &x)
+	c.Assert(err, qt.ErrorMatches, `unknown value "unknown" for MyEnum`)
+}
+
+func TestSchema(t *testing.T) {
+	c := qt.New(t)
+	at, err := avro.TypeOf(MyEnumA)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(at.String(), qt.JSONEquals, json.RawMessage(`{
+		"type": "enum",
+		"name": "MyEnum",
+		"symbols": ["a", "b", "c"]
+	}`))
+}

--- a/cmd/avro-generate-go/internal/generated_tests/simpleEnum/schema_gen.go
+++ b/cmd/avro-generate-go/internal/generated_tests/simpleEnum/schema_gen.go
@@ -3,7 +3,9 @@
 package simpleEnum
 
 import (
+	"fmt"
 	"github.com/heetch/avro/avrotypegen"
+	"strconv"
 )
 
 type MyEnum int
@@ -14,7 +16,41 @@ const (
 	MyEnumC
 )
 
-// TODO UnmarshalText and String methods.
+var _MyEnum_strings = []string{
+	"a",
+	"b",
+	"c",
+}
+
+// String returns the textual representation of MyEnum.
+func (e MyEnum) String() string {
+	if e < 0 || int(e) >= len(_MyEnum_strings) {
+		return "MyEnum(" + strconv.FormatInt(int64(e), 10) + ")"
+	}
+	return _MyEnum_strings[e]
+}
+
+// MarshalText implements encoding.TextMarshaler
+// by returning the textual representation of MyEnum.
+func (e MyEnum) MarshalText() ([]byte, error) {
+	if e < 0 || int(e) >= len(_MyEnum_strings) {
+		return nil, fmt.Errorf("MyEnum value %d is out of bounds", e)
+	}
+	return []byte(_MyEnum_strings[e]), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler
+// by expecting the textual representation of MyEnum.
+func (e *MyEnum) UnmarshalText(data []byte) error {
+	// Note for future: this could be more efficient.
+	for i, s := range _MyEnum_strings {
+		if string(data) == s {
+			*e = MyEnum(i)
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown value %q for MyEnum", data)
+}
 
 type R struct {
 	E MyEnum

--- a/cmd/avro-generate-go/internal/testutil/generatetest.go
+++ b/cmd/avro-generate-go/internal/testutil/generatetest.go
@@ -55,7 +55,7 @@ func (subtest RoundTripSubtest) runTest(c *qt.C, test RoundTripTest, inCodec *go
 
 	sanity, _, err := inCodec.NativeFromBinary(inData)
 	c.Assert(err, qt.Equals, nil)
-	pretty.Println("sanity: ", sanity)
+	c.Logf("sanity: %s", pretty.Sprint(sanity))
 
 	// Unmarshal the binary data into the Go type.
 	x := reflect.New(reflect.TypeOf(test.GoType).Elem())
@@ -63,7 +63,7 @@ func (subtest RoundTripSubtest) runTest(c *qt.C, test RoundTripTest, inCodec *go
 	c.Assert(err, qt.Equals, nil)
 	_, err = avro.Unmarshal(inData, x.Interface(), inType)
 	subtest.checkError(c, UnmarshalError, err, qt.Commentf("result data: %v", qt.Format(x.Interface())))
-	pretty.Println("unmarshaled: ", x.Interface())
+	c.Logf("unmarshaled: %s", pretty.Sprint(x.Interface()))
 
 	// Marshal the data back into binary and then into
 	// JSON, and check that it looks like we expect.

--- a/cmd/avro-generate-go/main.go
+++ b/cmd/avro-generate-go/main.go
@@ -69,7 +69,7 @@ func generateFile(f string) error {
 	}
 	resultData, err := format.Source(buf.Bytes())
 	if err != nil {
-		fmt.Printf("-------\n%s\n", buf.Bytes())
+		fmt.Printf("%s\n", buf.Bytes())
 		return fmt.Errorf("cannot format source: %v", err)
 	}
 

--- a/cmd/avro-generate-go/testdata/enum.cue
+++ b/cmd/avro-generate-go/testdata/enum.cue
@@ -17,3 +17,68 @@ tests: simpleEnum: {
 	inData: E: "b"
 	outData: inData
 }
+
+tests: simpleEnum: otherTests: """
+	package simpleEnum
+	import (
+		"encoding/json"
+		"testing"
+
+		qt "github.com/frankban/quicktest"
+
+		"github.com/heetch/avro"
+	)
+
+	func TestString(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(MyEnumA.String(), qt.Equals, "a")
+		c.Assert(MyEnumB.String(), qt.Equals, "b")
+		c.Assert(MyEnumC.String(), qt.Equals, "c")
+		c.Assert(MyEnum(-1).String(), qt.Equals, "MyEnum(-1)")
+		c.Assert(MyEnum(3).String(), qt.Equals, "MyEnum(3)")
+	}
+
+	func TestMarshalText(t *testing.T) {
+		c := qt.New(t)
+		data, err := MyEnumA.MarshalText()
+		c.Assert(err, qt.Equals, nil)
+		c.Assert(string(data), qt.Equals, "a")
+
+		data, err = MyEnum(-1).MarshalText()
+		c.Assert(err, qt.ErrorMatches, `MyEnum value -1 is out of bounds`)
+
+		data, err = MyEnum(3).MarshalText()
+		c.Assert(err, qt.ErrorMatches, `MyEnum value 3 is out of bounds`)
+	}
+
+	func TestUnmarshalText(t *testing.T) {
+		c := qt.New(t)
+		var e MyEnum
+		err := e.UnmarshalText([]byte("b"))
+		c.Assert(err, qt.Equals, nil)
+		c.Assert(e, qt.Equals, MyEnumB)
+
+		// Check that it works OK with encoding/json too.
+		var x struct {
+			E MyEnum
+		}
+		err = json.Unmarshal([]byte(`{"E": "c"}`), &x)
+		c.Assert(err, qt.Equals, nil)
+		c.Assert(x.E, qt.Equals, MyEnumC)
+
+		x.E = 0
+		err = json.Unmarshal([]byte(`{"E": "unknown"}`), &x)
+		c.Assert(err, qt.ErrorMatches, `unknown value "unknown" for MyEnum`)
+	}
+
+	func TestSchema(t *testing.T) {
+		c := qt.New(t)
+		at, err := avro.TypeOf(MyEnumA)
+		c.Assert(err, qt.Equals, nil)
+		c.Assert(at.String(), qt.JSONEquals, json.RawMessage(`{
+			"type": "enum",
+			"name": "MyEnum",
+			"symbols": ["a", "b", "c"]
+		}`))
+	}
+	"""

--- a/cmd/avro-generate-go/testdata/testschema.cue
+++ b/cmd/avro-generate-go/testdata/testschema.cue
@@ -20,6 +20,7 @@ roundTripTest :: {
 	inData?:        _
 	outData?:       _
 	expectError?: [errorKind]: string
+	otherTests?: string
 	subtests: [name=_]: {
 		testName: name
 		inData:   _


### PR DESCRIPTION
This means that generated enums can function better when
marshaled to JSON.

Fixes #12.