### PR TITLE
allow different names in non-union references

### DIFF
--- a/cmd/avro-generate-go/internal/generated_tests/cloudEvent/roundtrip_test.go
+++ b/cmd/avro-generate-go/internal/generated_tests/cloudEvent/roundtrip_test.go
@@ -29,7 +29,10 @@ var tests = testutil.RoundTripTest{
                                 },
                                 {
                                     "name": "time",
-                                    "type": "long"
+                                    "type": {
+                                        "type": "long",
+                                        "logicalType": "timestamp-micros"
+                                    }
                                 }
                             ],
                             "namespace": "avro.apache.org"
@@ -42,7 +45,7 @@ var tests = testutil.RoundTripTest{
                 ],
                 "namespace": "foo"
             }`,
-	GoType: new(SomeEvent),
+	GoType: new(CloudEvent),
 	Subtests: []testutil.RoundTripSubtest{{
 		TestName: "main",
 		InDataJSON: `{

--- a/cmd/avro-generate-go/internal/generated_tests/cloudEvent/schema.avsc
+++ b/cmd/avro-generate-go/internal/generated_tests/cloudEvent/schema.avsc
@@ -1,5 +1,5 @@
 {
-                "name": "SomeEvent",
+                "name": "CloudEvent",
                 "type": "record",
                 "fields": [
                     {
@@ -18,7 +18,10 @@
                                 },
                                 {
                                     "name": "time",
-                                    "type": "long"
+                                    "type": {
+                                        "type": "long",
+                                        "logicalType": "timestamp-micros"
+                                    }
                                 }
                             ],
                             "namespace": "avro.apache.org"

--- a/cmd/avro-generate-go/internal/generated_tests/cloudEvent/schema_gen.go
+++ b/cmd/avro-generate-go/internal/generated_tests/cloudEvent/schema_gen.go
@@ -4,18 +4,19 @@ package cloudEvent
 
 import (
 	"github.com/heetch/avro/avrotypegen"
+	"time"
 )
 
 type Metadata struct {
-	Id     string `json:"id"`
-	Source string `json:"source"`
-	Time   int64  `json:"time"`
+	Id     string    `json:"id"`
+	Source string    `json:"source"`
+	Time   time.Time `json:"time"`
 }
 
 // AvroRecord implements the avro.AvroRecord interface.
 func (Metadata) AvroRecord() avrotypegen.RecordInfo {
 	return avrotypegen.RecordInfo{
-		Schema: `{"fields":[{"name":"id","type":"string"},{"name":"source","type":"string"},{"name":"time","type":"long"}],"name":"Metadata","namespace":"avro.apache.org","type":"record"}`,
+		Schema: `{"fields":[{"name":"id","type":"string"},{"name":"source","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"Metadata","namespace":"avro.apache.org","type":"record"}`,
 		Required: []bool{
 			0: true,
 			1: true,
@@ -26,14 +27,14 @@ func (Metadata) AvroRecord() avrotypegen.RecordInfo {
 
 // TODO implement MarshalBinary and UnmarshalBinary methods?
 
-type SomeEvent struct {
+type CloudEvent struct {
 	Metadata Metadata
 }
 
 // AvroRecord implements the avro.AvroRecord interface.
-func (SomeEvent) AvroRecord() avrotypegen.RecordInfo {
+func (CloudEvent) AvroRecord() avrotypegen.RecordInfo {
 	return avrotypegen.RecordInfo{
-		Schema: `{"fields":[{"name":"Metadata","type":{"fields":[{"name":"id","type":"string"},{"name":"source","type":"string"},{"name":"time","type":"long"}],"name":"Metadata","namespace":"avro.apache.org","type":"record"}}],"name":"SomeEvent","namespace":"bar","type":"record"}`,
+		Schema: `{"fields":[{"name":"Metadata","type":{"fields":[{"name":"id","type":"string"},{"name":"source","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"Metadata","namespace":"avro.apache.org","type":"record"}}],"name":"CloudEvent","namespace":"bar","type":"record"}`,
 		Required: []bool{
 			0: true,
 		},

--- a/cmd/avro-generate-go/testdata/cloudevent.cue
+++ b/cmd/avro-generate-go/testdata/cloudevent.cue
@@ -19,8 +19,10 @@ tests: cloudEvent: {
 					type: "string"
 				}, {
 					name: "time"
-					type: "long"
-					// logicalType: "timestamp-micros"
+					type: {
+						type: "long"
+						logicalType: "timestamp-micros"
+					}
 				}]
 			}
 		}, {
@@ -29,7 +31,7 @@ tests: cloudEvent: {
 		}]
 	}
 	outSchema: {
-		name:      "SomeEvent"
+		name:      "CloudEvent"
 		namespace: "bar"
 		type:      "record"
 		fields: [{
@@ -46,8 +48,10 @@ tests: cloudEvent: {
 					type: "string"
 				}, {
 					name: "time"
-					type: "long"
-					// logicalType: "timestamp-micros"
+					type: {
+						type: "long"
+						logicalType: "timestamp-micros"
+					}
 				}]
 			}
 		}]

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/frankban/quicktest v1.7.2
 	github.com/kr/pretty v0.1.0
 	github.com/linkedin/goavro/v2 v2.9.7
-	github.com/rogpeppe/gogen-avro/v7 v7.0.0
+	github.com/rogpeppe/gogen-avro/v7 v7.1.0
 	gopkg.in/retry.v1 v1.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a h1:3QH7VyOaaiUHNrA9Se4YQIRkDTCw1EJls9xTUCaCeRM=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
-github.com/rogpeppe/gogen-avro/v7 v7.0.0 h1:NQVRmrqbeCwSE5upW1XJOqov3yW5O6y0lQytCwTOqzQ=
-github.com/rogpeppe/gogen-avro/v7 v7.0.0/go.mod h1:awhtQwpFg18PdUpdnOFr0ceVLYAn/oDCa/HE1hdbk50=
+github.com/rogpeppe/gogen-avro/v7 v7.1.0 h1:T1VvalNJFUZ8tGW6LKF4ZGSD9wis8B8wO2BfZLwM14c=
+github.com/rogpeppe/gogen-avro/v7 v7.1.0/go.mod h1:awhtQwpFg18PdUpdnOFr0ceVLYAn/oDCa/HE1hdbk50=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 gopkg.in/retry.v1 v1.0.3 h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=
 gopkg.in/retry.v1 v1.0.3/go.mod h1:FJkXmWiMaAo7xB+xhvDF59zhfjDWyzmyAxiT4dB688g=


### PR DESCRIPTION
This allows us to read a record without using the same name
when reading it, which matches the Java implementation and
means we can go with our current plan for encoding CloudEvent
metadata inside Kafka messages.

Note: this is reliant on the relevant update to the forked version of gogen-avro.