### PR TITLE
fix Unmarshal buffer corruption

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,74 @@
+package avro_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/heetch/avro"
+)
+
+func BenchmarkMarshal(b *testing.B) {
+	type R struct {
+		A *string
+		B *string
+		C []int
+	}
+	type T struct {
+		R R
+	}
+	x := T{
+		R: R{
+			A: newString("hello"),
+			B: newString("goodbye"),
+			C: []int{1, 3, 1 << 20},
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		_, _, err := avro.Marshal(x)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSingleDecoderUnmarshal(b *testing.B) {
+	c := qt.New(b)
+	type R struct {
+		A *string
+		B *string
+		C []int
+	}
+	type T struct {
+		R R
+	}
+	at, err := avro.TypeOf(T{})
+	c.Assert(err, qt.Equals, nil)
+	r := memRegistry{
+		1: at.String(),
+	}
+	enc := avro.NewSingleEncoder(r, nil)
+	ctx := context.Background()
+	data, err := enc.Marshal(ctx, T{
+		R: R{
+			A: newString("hello"),
+			B: newString("goodbye"),
+			C: []int{1, 3, 1 << 20},
+		},
+	})
+	c.Assert(err, qt.Equals, nil)
+
+	dec := avro.NewSingleDecoder(r, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var x T
+		_, err := dec.Unmarshal(ctx, data, &x)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func newString(s string) *string {
+	return &s
+}

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/frankban/quicktest v1.2.2 h1:xfmOhhoH5fGPgbEAlhLpJH9p0z/0Qizio9osmvn9IUY=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.7.2 h1:2QxQoC1TS09S7fhCPsrvqYdvP1H5M1P1ih5ABm3BTYk=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/gotype_test.go
+++ b/gotype_test.go
@@ -265,6 +265,32 @@ func TestProtobufGeneratedType(t *testing.T) {
 	}`))
 }
 
+func TestUnmarshalDoesNotCorruptData(t *testing.T) {
+	c := qt.New(t)
+	type R struct {
+		A *string
+		B *string
+	}
+	type T struct {
+		R R
+	}
+	x := T{
+		R: R{
+			A: newString("hello"),
+			B: newString("goodbye"),
+		},
+	}
+	data, at, err := avro.Marshal(x)
+	c.Assert(err, qt.Equals, nil)
+	origData := data
+	var x1 T
+	_, err = avro.Unmarshal(data, &x1, at)
+	c.Assert(err, qt.Equals, nil)
+	_, err = avro.Unmarshal(data, &x1, at)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(data, qt.DeepEquals, []byte(origData))
+}
+
 type OOBPanicEnum int
 
 var enumValues = []string{"a", "b"}

--- a/reader.go
+++ b/reader.go
@@ -26,6 +26,13 @@ func (d *decoder) fill(n int) int {
 	if len(d.buf)-d.scan >= n {
 		return n
 	}
+	if d.readErr != nil {
+		// If there's an error, there's no point in doing
+		// anything more. This is also crucial to avoid
+		// corrupting the buffer when it has been provided by a
+		// caller.
+		return len(d.buf) - d.scan
+	}
 	// Slide any remaining bytes to the
 	// start of the buffer.
 	total := copy(d.buf, d.buf[d.scan:])

--- a/singledecoder.go
+++ b/singledecoder.go
@@ -103,6 +103,9 @@ func (c *SingleDecoder) getProgram(ctx context.Context, vt reflect.Type, wID int
 		c.mu.RUnlock()
 		return prog, nil
 	}
+	if debugging {
+		debugf("no hit found for program %T schemaID %v", vt, wID)
+	}
 	wType := c.writerTypes[wID]
 	c.mu.RUnlock()
 
@@ -142,5 +145,6 @@ func (c *SingleDecoder) getProgram(ctx context.Context, vt reflect.Type, wID int
 		}
 		return nil, err
 	}
+	c.programs[decoderSchemaPair{vt, wID}] = prog
 	return prog, nil
 }

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -36,7 +36,9 @@ type azTypeInfo struct {
 }
 
 func newAzTypeInfo(t reflect.Type) (azTypeInfo, error) {
-	debugf("azTypeInfo(%v)", t)
+	if debugging {
+		debugf("azTypeInfo(%v)", t)
+	}
 	switch t.Kind() {
 	case reflect.Struct:
 		info := azTypeInfo{
@@ -84,12 +86,16 @@ func newAzTypeInfo(t reflect.Type) (azTypeInfo, error) {
 			entry := newAzTypeInfoFromField(f, required, makeDefault, unionInfo)
 			info.entries = append(info.entries, entry)
 		}
-		debugf("-> record, %d entries", len(info.entries))
+		if debugging {
+			debugf("-> record, %d entries", len(info.entries))
+		}
 		return info, nil
 	default:
 		// TODO check for top-level union types too.
 		// See https://github.com/heetch/avro/issues/13
-		debugf("-> unknown")
+		if debugging {
+			debugf("-> unknown")
+		}
 		return azTypeInfo{
 			ftype: t,
 		}, nil


### PR DESCRIPTION
Also speed up SingleDecoder a lot (we'd forgotten to cache
the compile results) and unmarshaling in general (the debugf
calls were really slowing things down).

Here are the new benchmark results after these changes have been
made:

```
BenchmarkMarshal-4                  	10628875	       551 ns/op	     240 B/op	       4 allocs/op
BenchmarkSingleDecoderUnmarshal-4   	 3596359	      1619 ns/op	     272 B/op	      14 allocs/op
```