### PR TITLE
avro: cache type encoders at top level only

### DIFF
--- a/names.go
+++ b/names.go
@@ -39,6 +39,12 @@ var builtinTypes = map[string]bool{
 	"null":    true,
 }
 
+// Marshal is like the Marshal function except that names
+// in the schema for x are renamed according to names.
+func (names *Names) Marshal(x interface{}) ([]byte, *Type, error) {
+	return marshalAppend(names, nil, reflect.ValueOf(x))
+}
+
 // Rename returns a copy of n that renames oldName to newName
 // with the given aliases when a schema is used.
 //


### PR DESCRIPTION
We'd like to provide the possibility to pair the encoding for a top level
type with a chosen schema.  That means we can't assume there's always
a specific association between Go type and Avro encoder for that type,
so we want to remove the use of the global cache in the body of the
encoder builder.

This is the first step towards allowing external definitions in generated
schema code.

This code doesn't change any externally-visible semantics.