### PR TITLE
cmd/avro-generate-go: use better defaults for flags

### DIFF
--- a/cmd/avro-generate-go/generate_test.go
+++ b/cmd/avro-generate-go/generate_test.go
@@ -1,5 +1,0 @@
-// Generate the tests.
-
-//go:generate go run ./generatetestcode.go
-
-package main

--- a/cmd/avro-generate-go/main.go
+++ b/cmd/avro-generate-go/main.go
@@ -7,7 +7,7 @@
 //	  -d string
 //	    	directory to write Go files to (default ".")
 //	  -p string
-//	    	package name
+//	    	package name (defaults to $GOPACKAGE)
 //	  -t	generated files will have _test.go suffix
 package main
 
@@ -22,10 +22,14 @@ import (
 	"strings"
 )
 
+// Generate the tests.
+
+//go:generate go run ./generatetestcode.go
+
 var (
 	dirFlag  = flag.String("d", ".", "directory to write Go files to")
-	pkgFlag  = flag.String("p", "", "package name")
-	testFlag = flag.Bool("t", false, "generated files will have _test.go suffix")
+	pkgFlag  = flag.String("p", os.Getenv("GOPACKAGE"), "package name (defaults to $GOPACKAGE)")
+	testFlag = flag.Bool("t", strings.HasSuffix(os.Getenv("GOFILE"), "_test.go"), "generated files will have _test.go suffix (defaults to true if $GOFILE is a test file)")
 )
 
 func main() {
@@ -40,7 +44,7 @@ func main() {
 		flag.Usage()
 	}
 	if *pkgFlag == "" {
-		fmt.Fprintf(os.Stderr, "avrogen: -p flag must specify a package name\n")
+		fmt.Fprintf(os.Stderr, "avrogen: -p flag must specify a package name or set $GOPACKAGE\n")
 		os.Exit(1)
 	}
 	if err := generateFiles(files); err != nil {

--- a/singledecoder_test.go
+++ b/singledecoder_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/heetch/avro"
 )
 
-//go:generate avro-generate-go -t -p avro_test testschema1.avsc
+//go:generate avro-generate-go testschema1.avsc
 
 func TestSingleDecoder(t *testing.T) {
 	c := qt.New(t)


### PR DESCRIPTION
Given that avro-generate-go is conventionally invoked in
a `go generate` context and thus is provided with `$GOPACKAGE`
and `$GOFILE` environment variables, we can make a better
guess about the likely values for the `-p` and `-t` flags, so do that.