### PR TITLE
avro: add CanonicalString method

### DIFF
--- a/type.go
+++ b/type.go
@@ -1,6 +1,10 @@
 package avro
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	"github.com/rogpeppe/gogen-avro/v7/schema"
 
 	"github.com/heetch/avro/internal/typeinfo"
@@ -27,6 +31,143 @@ func ParseType(s string) (*Type, error) {
 
 func (t *Type) String() string {
 	return t.schema
+}
+
+// CanonicalOpts holds a bitmask of options for CanonicalString.
+type CanonicalOpts int
+
+const (
+	// LeaveDefaults specifies that default values should be retained in
+	// the canonicalized schema string.
+	LeaveDefaults CanonicalOpts = 1 << iota
+)
+
+// CanonicalString returns the canonical string representation of the type,
+// as documented here: https://avro.apache.org/docs/1.9.1/spec.html#Transforming+into+Parsing+Canonical+Form
+//
+// BUG: Unicode characters \u2028 and \u2029 in strings inside the schema are always escaped, contrary to the
+// specification above.
+func (t *Type) CanonicalString(opts CanonicalOpts) string {
+	c := &canonicalizer{
+		defined: make(map[schema.QualifiedName]bool),
+		opts:    opts,
+	}
+	v := c.canonicalValue(t.avroType)
+
+	// Use a Encoder rather than MarshalJSON directly so that
+	// we can disable escaping of HTML metacharacters.
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		panic(err)
+	}
+	return strings.TrimSuffix(buf.String(), "\n")
+}
+
+type canonicalizer struct {
+	defined map[schema.QualifiedName]bool
+	opts    CanonicalOpts
+}
+
+// canonicalFields holds all the fields that can be produced as part
+// of a canonical schema representation in the order defined
+// by the spec.
+type canonicalFields struct {
+	Name    string            `json:"name,omitempty"`
+	Type    interface{}       `json:"type,omitempty"`
+	Fields  []canonicalFields `json:"fields,omitempty"`
+	Symbols []string          `json:"symbols,omitempty"`
+	Items   interface{}       `json:"items,omitempty"`
+	Size    int               `json:"size,omitempty"`
+	Values  interface{}       `json:"values,omitempty"`
+	// The default field isn't mentioned in the specification, but is
+	// important to store in the registry, so we allow it to be
+	// kept with the LeaveDefaults option to CanonicalString.
+	// TODO the Avro spec doesn't define canonicalization for
+	// floating point values, which could be an issue.
+	Default interface{} `json:"default,omitempty"`
+}
+
+func (c *canonicalizer) canonicalValue(at schema.AvroType) interface{} {
+	switch at := at.(type) {
+	case *schema.ArrayField:
+		return canonicalFields{
+			Type:  "array",
+			Items: c.canonicalValue(at.ItemType()),
+		}
+	case *schema.BoolField:
+		return "boolean"
+	case *schema.BytesField:
+		return "bytes"
+	case *schema.DoubleField:
+		return "double"
+	case *schema.FloatField:
+		return "float"
+	case *schema.IntField:
+		return "int"
+	case *schema.LongField:
+		return "long"
+	case *schema.NullField:
+		return "null"
+	case *schema.StringField:
+		return "string"
+	case *schema.MapField:
+		return canonicalFields{
+			Type:  "map",
+			Items: c.canonicalValue(at.ItemType()),
+		}
+	case *schema.UnionField:
+		cf := make([]interface{}, len(at.ItemTypes()))
+		for i, t := range at.ItemTypes() {
+			cf[i] = c.canonicalValue(t)
+		}
+		return cf
+	case *schema.Reference:
+		if c.defined[at.TypeName] {
+			return at.TypeName.String()
+		}
+		c.defined[at.TypeName] = true
+		switch def := at.Def.(type) {
+		case *schema.EnumDefinition:
+			// TODO enum default
+			return canonicalFields{
+				Name:    def.AvroName().String(),
+				Type:    "enum",
+				Symbols: def.Symbols(),
+			}
+		case *schema.FixedDefinition:
+			return canonicalFields{
+				Name: def.AvroName().String(),
+				Type: "fixed",
+				Size: def.SizeBytes(),
+			}
+		case *schema.RecordDefinition:
+			fields := def.Fields()
+			cf := canonicalFields{
+				Name:   def.AvroName().String(),
+				Type:   "record",
+				Fields: make([]canonicalFields, len(fields)),
+			}
+			for i, f := range fields {
+				// It's possible that the order field should be stored in the
+				// registry, but it doesn't seem necessary for now, so we
+				// omit it.
+				cf.Fields[i] = canonicalFields{
+					Name: f.Name(),
+					Type: c.canonicalValue(f.Type()),
+				}
+				if f.HasDefault() && (c.opts&LeaveDefaults) != 0 {
+					cf.Fields[i].Default = f.Default()
+				}
+			}
+			return cf
+		default:
+			panic(fmt.Errorf("unknown definition type %T", def))
+		}
+	default:
+		panic(fmt.Errorf("unknown Avro type %T", at))
+	}
 }
 
 // name returns the fully qualified Avro name for the type,

--- a/type_test.go
+++ b/type_test.go
@@ -1,0 +1,182 @@
+package avro_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/heetch/avro"
+)
+
+// NOTE: the INTEGERS part of the canonicalizing specification is redundant
+// because JSON doesn't allow leading zeros anyway.
+
+var canonicalStringTests = []struct {
+	testName string
+	opts     avro.CanonicalOpts
+	in       string
+	out      string
+}{{
+	testName: "spec-WHITESPACE",
+	in:       "    \"string\"   \n ",
+	out:      `"string"`,
+}, {
+	testName: "spec-PRIMITIVES",
+	in:       `{"type": "int"}`,
+	out:      `"int"`,
+}, {
+	testName: "spec-STRIP",
+	opts:     avro.LeaveDefaults,
+	in: `{
+	"type": "record",
+	"name":"R",
+	"doc": "documentation",
+	"extra-meta":"hello",
+	"aliases": ["a", "b"],
+	"fields": [{
+		"name": "a",
+		"type": "string",
+		"default": "hello"
+	}]}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string","default":"hello"}]}`,
+}, {
+	testName: "spec-STRIP-include-defaults",
+	in: `{
+	"type": "record",
+	"name":"R",
+	"doc": "documentation",
+	"extra-meta":"hello",
+	"aliases": ["a", "b"],
+	"fields": [{
+		"name": "a",
+		"type": "string",
+		"default": "hello"
+	}]}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string"}]}`,
+}, {
+	testName: "spec-ORDER",
+	in: `{
+		"fields":[{
+			"name":"a",
+			"type":"string"
+		}, {
+			"name": "b",
+			"type": {
+				"symbols": ["x", "y"],
+				"type": "enum",
+				"name": "E"
+			}
+		}, {
+			"name": "c",
+			"type": {
+				"items": "int",
+				"type": "array"
+			}
+		}, {
+			"name": "d",
+			"type": {
+				"values": "int",
+				"type": "map"
+			}
+		}, {
+			"name": "e",
+			"type": {
+				"size": 20,
+				"type": "fixed",
+				"name": "F"
+			}
+		}],
+		"type":"record",
+		"name":"R"
+	}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string"},{"name":"b","type":{"name":"E","type":"enum","symbols":["x","y"]}},{"name":"c","type":{"type":"array","items":"int"}},{"name":"d","type":{"type":"map","items":"int"}},{"name":"e","type":{"name":"F","type":"fixed","size":20}}]}`,
+}, {
+	testName: "spec-STRINGS",
+	opts:     avro.LeaveDefaults,
+	in: `{
+		"name":"\u0052",
+		"type":"record",
+		"fields":[{
+			"name":"a",
+			"type":"string",
+			"default":"hello<>&\u00e9\u003e"
+		}]
+	}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string","default":"hello<>&é>"}]}`,
+}, {
+	in: `{
+	"name": "R",
+	"namespace": "com.example",
+	"type": "record",
+	"fields": [{
+		"name": "a",
+		"type": {
+			"type": "enum",
+			"name": "E",
+			"symbols": ["a", "b"]
+		}
+	}, {
+		"name": "b",
+		"type": {
+			"type": "enum",
+			"name": "foo.F",
+			"symbols": ["a", "b"]
+		}
+	}, {
+		"name": "c",
+		"type": "E"
+	}]
+}`,
+	out: `{"name":"com.example.R","type":"record","fields":[{"name":"a","type":{"name":"com.example.E","type":"enum","symbols":["a","b"]}},{"name":"b","type":{"name":"foo.F","type":"enum","symbols":["a","b"]}},{"name":"c","type":"com.example.E"}]}`,
+}, {
+	testName: "primitive_types",
+	in: `{
+	"name": "R",
+	"type": "record",
+	"fields": [{
+		"name": "a",
+		"type": "int"
+	}, {
+		"name": "b",
+		"type": "long"
+	}, {
+		"name": "c",
+		"type": "float"
+	}, {
+		"name": "d",
+		"type": "double"
+	}, {
+		"name": "e",
+		"type": "null"
+	}, {
+		"name": "f",
+		"type": "long"
+	}, {
+		"name": "g",
+		"type": "boolean"
+	}, {
+		"name": "h",
+		"type": "bytes"
+	}]
+}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"int"},{"name":"b","type":"long"},{"name":"c","type":"float"},{"name":"d","type":"double"},{"name":"e","type":"null"},{"name":"f","type":"long"},{"name":"g","type":"boolean"},{"name":"h","type":"bytes"}]}`,
+}, {
+	testName: "union",
+	in: `["int","string", {
+		"type": "enum",
+		"name": "E",
+		"symbols": ["a", "b"]
+	}]`,
+	out: `["int","string",{"name":"E","type":"enum","symbols":["a","b"]}]`,
+}}
+
+func TestCanonicalString(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range canonicalStringTests {
+		c.Run(test.testName, func(c *qt.C) {
+			t, err := avro.ParseType(test.in)
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(t.CanonicalString(test.opts), qt.Equals, test.out)
+		})
+	}
+}


### PR DESCRIPTION
Because of https://github.com/confluentinc/schema-registry/issues/1348, we
need to be sure that schemas added to the registry and searched in the registry
don't have extra metadata that can cause the search to fail.

To do that, we implement the canonical parsing normalization as specified
in the [Avro spec](https://avro.apache.org/docs/1.9.1/spec.html#Transforming+into+Parsing+Canonical+Form), with the addition that defaults can also be retained.