### PR TITLE
avroregistry: canonicalize schemas when registering and getting

### DIFF
--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -80,10 +80,12 @@ func (r *Registry) Decoder() avro.DecodingRegistry {
 // with the given subject and returns its id.
 //
 // See https://docs.confluent.io/current/schema-registry/develop/api.html#post--subjects-(string-%20subject)-versions
-func (r *Registry) Register(ctx context.Context, subject, schema string) (int64, error) {
+func (r *Registry) Register(ctx context.Context, subject string, schema *avro.Type) (int64, error) {
+	// Note: because of https://github.com/confluentinc/schema-registry/issues/1348
+	// we need to strip metadata from the schema when registering.
 	data, err := json.Marshal(struct {
 		Schema string `json:"schema"`
-	}{schema})
+	}{schema.CanonicalString(avro.LeaveDefaults)})
 	if err != nil {
 		return 0, err
 	}

--- a/bench_test.go
+++ b/bench_test.go
@@ -45,7 +45,7 @@ func BenchmarkSingleDecoderUnmarshal(b *testing.B) {
 	at, err := avro.TypeOf(T{})
 	c.Assert(err, qt.Equals, nil)
 	r := memRegistry{
-		1: at.String(),
+		1: at,
 	}
 	enc := avro.NewSingleEncoder(r, nil)
 	ctx := context.Background()

--- a/singledecoder.go
+++ b/singledecoder.go
@@ -20,7 +20,7 @@ type DecodingRegistry interface {
 	DecodeSchemaID(msg []byte) (int64, []byte)
 
 	// SchemaForID returns the schema for the given ID.
-	SchemaForID(ctx context.Context, id int64) (string, error)
+	SchemaForID(ctx context.Context, id int64) (*Type, error)
 }
 
 type decoderSchemaPair struct {
@@ -116,11 +116,7 @@ func (c *SingleDecoder) getProgram(ctx context.Context, vt reflect.Type, wID int
 		}
 	} else {
 		// We haven't seen the writer schema before, so try to fetch it.
-		var s string
-		s, err = c.registry.SchemaForID(ctx, wID)
-		if err == nil {
-			wType, err = ParseType(s)
-		}
+		wType, err = c.registry.SchemaForID(ctx, wID)
 		// TODO look at the SchemaForID error
 		// and return an error without caching it if it's temporary?
 		// See https://github.com/heetch/avro/issues/39

--- a/singleencoder.go
+++ b/singleencoder.go
@@ -14,7 +14,7 @@ type EncodingRegistry interface {
 	AppendSchemaID(buf []byte, id int64) []byte
 
 	// IDForSchema returns an ID for the given schema.
-	IDForSchema(ctx context.Context, schema string) (int64, error)
+	IDForSchema(ctx context.Context, schema *Type) (int64, error)
 }
 
 // SingleEncoder encodes messages in Avro binary format.
@@ -74,7 +74,7 @@ func (enc *SingleEncoder) idForType(ctx context.Context, t reflect.Type) (int64,
 	if err != nil {
 		return 0, err
 	}
-	id1, err := enc.registry.IDForSchema(ctx, avroType.String())
+	id1, err := enc.registry.IDForSchema(ctx, avroType)
 	if err != nil {
 		return 0, err
 	}

--- a/singleencoder_test.go
+++ b/singleencoder_test.go
@@ -14,7 +14,7 @@ func TestSingleEncoder(t *testing.T) {
 	c := qt.New(t)
 	avroType := mustTypeOf(TestRecord{})
 	registry := memRegistry{
-		1: avroType.String(),
+		1: avroType,
 	}
 	enc := avro.NewSingleEncoder(registry, nil)
 	data, err := enc.Marshal(context.Background(), TestRecord{A: 20, B: 34})
@@ -47,7 +47,7 @@ func TestSingleEncoderCachesTypes(t *testing.T) {
 	c := qt.New(t)
 	registry := &statsRegistry{
 		memRegistry: memRegistry{
-			1: mustTypeOf(TestRecord{}).String(),
+			1: mustTypeOf(TestRecord{}),
 		},
 	}
 	enc := avro.NewSingleEncoder(registry, nil)
@@ -76,8 +76,8 @@ func TestSingleEncoderRace(t *testing.T) {
 		B int
 	}
 	registry := memRegistry{
-		1: mustTypeOf(T1{}).String(),
-		2: mustTypeOf(T2{}).String(),
+		1: mustTypeOf(T1{}),
+		2: mustTypeOf(T2{}),
 	}
 	enc := avro.NewSingleEncoder(registry, nil)
 	var wg sync.WaitGroup
@@ -100,12 +100,12 @@ type statsRegistry struct {
 	memRegistry
 }
 
-func (r *statsRegistry) IDForSchema(ctx context.Context, schema string) (int64, error) {
+func (r *statsRegistry) IDForSchema(ctx context.Context, schema *avro.Type) (int64, error) {
 	r.idForSchemaCount++
 	return r.memRegistry.IDForSchema(ctx, schema)
 }
 
-func (r *statsRegistry) SchemaForID(ctx context.Context, id int64) (string, error) {
+func (r *statsRegistry) SchemaForID(ctx context.Context, id int64) (*avro.Type, error) {
 	r.schemaForIDCount++
 	return r.memRegistry.SchemaForID(ctx, id)
 }

--- a/type_test.go
+++ b/type_test.go
@@ -180,3 +180,11 @@ func TestCanonicalString(t *testing.T) {
 		})
 	}
 }
+
+func mustParseType(s string) *avro.Type {
+	t, err := avro.ParseType(s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}


### PR DESCRIPTION
As this means that the registry needs to use the `CanonicalString` method,
we want to avoid the extra round-trip through `ParseType`, so we change
the signature of the `EncodingRegistry` interface so that it takes
a `*avro.Type` rather than a string, and we also make a similar
change in `DecodingRegistry` for consistency.

This works around this bug in the Schema registry: https://github.com/confluentinc/schema-registry/issues/1348
