### PR TITLE
allow retaining logical types in CanonicalString

### DIFF
--- a/avroregistry/message.go
+++ b/avroregistry/message.go
@@ -38,7 +38,7 @@ func (r encodingRegistry) AppendSchemaID(buf []byte, id int64) []byte {
 func (r encodingRegistry) IDForSchema(ctx context.Context, schema *avro.Type) (int64, error) {
 	data, err := json.Marshal(struct {
 		Schema string `json:"schema"`
-	}{schema.CanonicalString(avro.LeaveDefaults)})
+	}{canonical(schema)})
 	if err != nil {
 		return 0, err
 	}

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -85,7 +85,7 @@ func (r *Registry) Register(ctx context.Context, subject string, schema *avro.Ty
 	// we need to strip metadata from the schema when registering.
 	data, err := json.Marshal(struct {
 		Schema string `json:"schema"`
-	}{schema.CanonicalString(avro.LeaveDefaults)})
+	}{canonical(schema)})
 	if err != nil {
 		return 0, err
 	}
@@ -183,4 +183,8 @@ type apiError struct {
 
 func (e *apiError) Error() string {
 	return fmt.Sprintf("Avro registry error (code %d): %v", e.ErrorCode, e.Message)
+}
+
+func canonical(schema *avro.Type) string {
+	return schema.CanonicalString(avro.RetainDefaults | avro.RetainLogicalTypes)
 }

--- a/avroregistry/registry_test.go
+++ b/avroregistry/registry_test.go
@@ -77,6 +77,21 @@ func TestSchemaCompatibility(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `Avro registry error \(code 409\): Schema being registered is incompatible with an earlier schema`)
 }
 
+func TestSchemasRetainLogicalTypes(t *testing.T) {
+	c := qt.New(t)
+	defer c.Done()
+	r, subject := newTestRegistry(c)
+	ctx := context.Background()
+	type R struct {
+		T time.Time
+	}
+	id, err := r.Register(ctx, subject, schemaOf(nil, R{}))
+	c.Assert(err, qt.Equals, nil)
+	schema, err := r.Decoder().SchemaForID(ctx, id)
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(schema.String(), qt.Equals, `{"type":"record","name":"R","fields":[{"name":"T","type":{"type":"long","logicalType":"timestamp-micros"},"default":0}]}`)
+}
+
 func TestSingleCodec(t *testing.T) {
 	c := qt.New(t)
 	defer c.Done()

--- a/type_test.go
+++ b/type_test.go
@@ -26,7 +26,6 @@ var canonicalStringTests = []struct {
 	out:      `"int"`,
 }, {
 	testName: "spec-STRIP",
-	opts:     avro.LeaveDefaults,
 	in: `{
 	"type": "record",
 	"name":"R",
@@ -37,10 +36,17 @@ var canonicalStringTests = []struct {
 		"name": "a",
 		"type": "string",
 		"default": "hello"
+	}, {
+		"name": "b",
+		"type": {
+			"type": "long",
+			"logicalType": "timestamp-millis"
+		}
 	}]}`,
-	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string","default":"hello"}]}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string"},{"name":"b","type":"long"}]}`,
 }, {
-	testName: "spec-STRIP-include-defaults",
+	testName: "spec-STRIP-retain-defaults",
+	opts:     avro.RetainDefaults,
 	in: `{
 	"type": "record",
 	"name":"R",
@@ -51,8 +57,72 @@ var canonicalStringTests = []struct {
 		"name": "a",
 		"type": "string",
 		"default": "hello"
+	}, {
+		"name": "b",
+		"type": {
+			"type": "long",
+			"logicalType": "timestamp-micros"
+		}
 	}]}`,
-	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string"}]}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string","default":"hello"},{"name":"b","type":"long"}]}`,
+}, {
+	testName: "spec-STRIP-retain-logical-types",
+	opts:     avro.RetainLogicalTypes,
+	in: `{
+	"type": "record",
+	"name":"R",
+	"doc": "documentation",
+	"extra-meta":"hello",
+	"aliases": ["a", "b"],
+	"fields": [{
+		"name": "a",
+		"type": "string",
+		"default": "hello"
+	}, {
+		"name": "b",
+		"type": {
+			"type": "long",
+			"logicalType": "timestamp-micros"
+		}
+	}, {
+		"name": "c",
+		"type": {
+			"type": "bytes",
+			"logicalType": "decimal",
+			"scale": 3,
+			"precision": 6
+		}
+	}, {
+		"name": "d",
+		"type": {
+			"type": "bytes",
+			"logicalType": "decimal",
+			"scale": 0,
+			"precision": 6
+		}
+	}]}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string"},{"name":"b","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"c","type":{"type":"bytes","logicalType":"decimal","precision":6,"scale":3}},{"name":"d","type":{"type":"bytes","logicalType":"decimal","precision":6}}]}`,
+}, {
+	testName: "spec-STRIP-retain-all",
+	opts:     avro.RetainAll,
+	in: `{
+	"type": "record",
+	"name":"R",
+	"doc": "documentation",
+	"extra-meta":"hello",
+	"aliases": ["a", "b"],
+	"fields": [{
+		"name": "a",
+		"type": "string",
+		"default": "hello"
+	}, {
+		"name": "b",
+		"type": {
+			"type": "long",
+			"logicalType": "timestamp-micros"
+		}
+	}]}`,
+	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string","default":"hello"},{"name":"b","type":{"type":"long","logicalType":"timestamp-micros"}}]}`,
 }, {
 	testName: "spec-ORDER",
 	in: `{
@@ -92,7 +162,7 @@ var canonicalStringTests = []struct {
 	out: `{"name":"R","type":"record","fields":[{"name":"a","type":"string"},{"name":"b","type":{"name":"E","type":"enum","symbols":["x","y"]}},{"name":"c","type":{"type":"array","items":"int"}},{"name":"d","type":{"type":"map","values":"int"}},{"name":"e","type":{"name":"F","type":"fixed","size":20}}]}`,
 }, {
 	testName: "spec-STRINGS",
-	opts:     avro.LeaveDefaults,
+	opts:     avro.RetainDefaults,
 	in: `{
 		"name":"\u0052",
 		"type":"record",


### PR DESCRIPTION
Use this functionality to retain logical types in the schemas
stored in the registry. This means that we'll be able to do
schema-resolution checks that logical types haven't inappropriately
changed (for example that the scale on a decimal value is the same)
or generate appropriate conversion code.

Somewhat gratuitously (but it's very early days, so hopefully OK)
we change the naming of the canonicalization constants to use
a `Retain` prefix instead of `Leave`, as that seems less ambiguous.