### PR TITLE
avro: better support for Avro null type

### DIFF
--- a/avrotypegen/typeinfo.go
+++ b/avrotypegen/typeinfo.go
@@ -2,6 +2,8 @@
 // This is an implementation detail and this might change over time.
 package avrotypegen
 
+import "fmt"
+
 // AvroRecord is implemented by Go types generated
 // by the avrogo command.
 type AvroRecord interface {
@@ -47,4 +49,21 @@ type UnionInfo struct {
 	// The info can be omitted if Type is a pointer
 	// and the union is ["null", T].
 	Union []UnionInfo
+}
+
+// Null represents the Avro null type. Its only JSON representation is null.
+type Null struct{}
+
+// UnmarshalJSON implements json.Unmarshaler by requiring
+// the JSON value to be null.
+func (Null) UnmarshalJSON(data []byte) error {
+	if string(data) != "null" {
+		return fmt.Errorf("cannot unmarshal %q into avro.Null", data)
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler by returning "null".
+func (Null) MarshalJSON() ([]byte, error) {
+	return []byte("null"), nil
 }

--- a/cmd/avrogo/generate.go
+++ b/cmd/avrogo/generate.go
@@ -445,7 +445,7 @@ func (gc *generateContext) GoTypeOf(t schema.AvroType) typeInfo {
 	var info typeInfo
 	switch t := t.(type) {
 	case *schema.NullField:
-		info.GoType = "nil"
+		info.GoType = "avrotypegen.Null"
 	case *schema.BoolField:
 		info.GoType = "bool"
 	case *schema.IntField:

--- a/cmd/avrogo/internal/generated_tests/primitive/roundtrip_test.go
+++ b/cmd/avrogo/internal/generated_tests/primitive/roundtrip_test.go
@@ -40,6 +40,10 @@ var tests = testutil.RoundTripTest{
                     {
                         "name": "stringField",
                         "type": "string"
+                    },
+                    {
+                        "name": "nullField",
+                        "type": "null"
                     }
                 ]
             }`,
@@ -53,7 +57,8 @@ var tests = testutil.RoundTripTest{
                         "doubleField": 2E-50,
                         "boolField": true,
                         "bytesField": "stuff",
-                        "stringField": "hello world"
+                        "stringField": "hello world",
+                        "nullField": null
                     }`,
 		OutDataJSON: `{
                         "intField": 2147483647,
@@ -62,7 +67,8 @@ var tests = testutil.RoundTripTest{
                         "doubleField": 2E-50,
                         "boolField": true,
                         "bytesField": "stuff",
-                        "stringField": "hello world"
+                        "stringField": "hello world",
+                        "nullField": null
                     }`,
 	}, {
 		TestName: "lowValues",
@@ -73,7 +79,8 @@ var tests = testutil.RoundTripTest{
                         "doubleField": -2E-50,
                         "boolField": false,
                         "bytesField": "",
-                        "stringField": ""
+                        "stringField": "",
+                        "nullField": null
                     }`,
 		OutDataJSON: `{
                         "intField": -2147483648,
@@ -82,7 +89,8 @@ var tests = testutil.RoundTripTest{
                         "doubleField": -2E-50,
                         "boolField": false,
                         "bytesField": "",
-                        "stringField": ""
+                        "stringField": "",
+                        "nullField": null
                     }`,
 	}},
 }

--- a/cmd/avrogo/internal/generated_tests/primitive/schema.avsc
+++ b/cmd/avrogo/internal/generated_tests/primitive/schema.avsc
@@ -29,6 +29,10 @@
                     {
                         "name": "stringField",
                         "type": "string"
+                    },
+                    {
+                        "name": "nullField",
+                        "type": "null"
                     }
                 ]
             }

--- a/cmd/avrogo/internal/generated_tests/primitive/schema_gen.go
+++ b/cmd/avrogo/internal/generated_tests/primitive/schema_gen.go
@@ -7,19 +7,20 @@ import (
 )
 
 type R struct {
-	IntField    int     `json:"intField"`
-	LongField   int64   `json:"longField"`
-	FloatField  float32 `json:"floatField"`
-	DoubleField float64 `json:"doubleField"`
-	BoolField   bool    `json:"boolField"`
-	BytesField  []byte  `json:"bytesField"`
-	StringField string  `json:"stringField"`
+	IntField    int              `json:"intField"`
+	LongField   int64            `json:"longField"`
+	FloatField  float32          `json:"floatField"`
+	DoubleField float64          `json:"doubleField"`
+	BoolField   bool             `json:"boolField"`
+	BytesField  []byte           `json:"bytesField"`
+	StringField string           `json:"stringField"`
+	NullField   avrotypegen.Null `json:"nullField"`
 }
 
 // AvroRecord implements the avro.AvroRecord interface.
 func (R) AvroRecord() avrotypegen.RecordInfo {
 	return avrotypegen.RecordInfo{
-		Schema: `{"fields":[{"name":"intField","type":"int"},{"name":"longField","type":"long"},{"name":"floatField","type":"float"},{"name":"doubleField","type":"double"},{"name":"boolField","type":"boolean"},{"name":"bytesField","type":"bytes"},{"name":"stringField","type":"string"}],"name":"R","type":"record"}`,
+		Schema: `{"fields":[{"name":"intField","type":"int"},{"name":"longField","type":"long"},{"name":"floatField","type":"float"},{"name":"doubleField","type":"double"},{"name":"boolField","type":"boolean"},{"name":"bytesField","type":"bytes"},{"name":"stringField","type":"string"},{"name":"nullField","type":"null"}],"name":"R","type":"record"}`,
 		Required: []bool{
 			0: true,
 			1: true,
@@ -28,6 +29,7 @@ func (R) AvroRecord() avrotypegen.RecordInfo {
 			4: true,
 			5: true,
 			6: true,
+			7: true,
 		},
 	}
 }

--- a/cmd/avrogo/internal/generated_tests/simpleInUnionOut/schema_gen.go
+++ b/cmd/avrogo/internal/generated_tests/simpleInUnionOut/schema_gen.go
@@ -14,7 +14,7 @@ type R struct {
 	// 	float64
 	// 	string
 	// 	bool
-	// 	nil
+	// 	avrotypegen.Null
 	UnionField interface{}
 }
 
@@ -43,7 +43,7 @@ func (R) AvroRecord() avrotypegen.RecordInfo {
 				}, {
 					Type: new(bool),
 				}, {
-					Type: nil,
+					Type: new(avrotypegen.Null),
 				}},
 			},
 		},

--- a/cmd/avrogo/internal/generated_tests/unionInOut/schema_gen.go
+++ b/cmd/avrogo/internal/generated_tests/unionInOut/schema_gen.go
@@ -14,7 +14,7 @@ type PrimitiveUnionTestRecord struct {
 	// 	float64
 	// 	string
 	// 	bool
-	// 	nil
+	// 	avrotypegen.Null
 	UnionField interface{}
 }
 
@@ -43,7 +43,7 @@ func (PrimitiveUnionTestRecord) AvroRecord() avrotypegen.RecordInfo {
 				}, {
 					Type: new(bool),
 				}, {
-					Type: nil,
+					Type: new(avrotypegen.Null),
 				}},
 			},
 		},

--- a/cmd/avrogo/testdata/primitive.cue
+++ b/cmd/avrogo/testdata/primitive.cue
@@ -27,6 +27,9 @@ tests: primitive: {
 		}, {
 			name: "stringField"
 			type: "string"
+		}, {
+			name: "nullField"
+			type: "null"
 		}]
 	}
 	outSchema: inSchema
@@ -43,6 +46,7 @@ tests: primitive: subtests: highValues: {
 		// https://github.com/linkedin/goavro/issues/192
 		bytesField:  "stuff"
 		stringField: "hello world"
+		nullField: null
 	}
 	outData: inData
 }
@@ -58,6 +62,7 @@ tests: primitive: subtests: lowValues: {
 		// https://github.com/linkedin/goavro/issues/192
 		bytesField:  ""
 		stringField: ""
+		nullField: null
 	}
 	outData: inData
 }

--- a/encode.go
+++ b/encode.go
@@ -215,6 +215,8 @@ func (b *encoderBuilder) typeEncoder(at schema.AvroType, t reflect.Type, info ty
 		return floatEncoder
 	case *schema.IntField:
 		return longEncoder
+	case *schema.NullField:
+		return nullEncoder
 	case *schema.LongField:
 		if t == timeType {
 			if lt := logicalType(at); lt == timestampMicros {
@@ -322,6 +324,9 @@ func boolEncoder(e *encodeState, v reflect.Value) {
 	} else {
 		e.WriteByte(0)
 	}
+}
+
+func nullEncoder(e *encodeState, v reflect.Value) {
 }
 
 func longEncoder(e *encodeState, v reflect.Value) {

--- a/gotype_test.go
+++ b/gotype_test.go
@@ -48,6 +48,31 @@ func TestSimpleGoType(t *testing.T) {
 	wg.Wait()
 }
 
+func TestGoTypeWithNull(t *testing.T) {
+	c := qt.New(t)
+	type T struct {
+		A, B avro.Null
+	}
+	data, wType, err := avro.Marshal(T{})
+	c.Assert(err, qt.Equals, nil)
+	c.Assert(data, qt.HasLen, 0)
+	c.Assert(wType.String(), qt.JSONEquals, json.RawMessage(`{
+		"type": "record",
+		"name": "T",
+		"fields": [{
+			"name": "A",
+			"default": null,
+			"type": "null"
+		}, {
+			"name": "B",
+			"default": null,
+			"type": "null"
+		}]
+	}`))
+	_, err = avro.Unmarshal(nil, new(T), wType)
+	c.Assert(err, qt.Equals, nil)
+}
+
 func TestEmptyGoStructType(t *testing.T) {
 	c := qt.New(t)
 	type T struct{}


### PR DESCRIPTION
It's sometimes useful to be able to use an explicit Avro null type.
This change adds a new special Go type (`avro.Null`) that can only be null
and is recognized to be the canonical representation of the Avro null type.

Partially fixes #75.