### PR TITLE
cmd/avrogo: fix output file names

### DIFF
--- a/cmd/avrogo/externaltype.go
+++ b/cmd/avrogo/externaltype.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 
 	"github.com/rogpeppe/gogen-avro/v7/parser"
@@ -144,7 +145,7 @@ func externalTypeInfoForGoTypes(gts map[goType]bool) (map[goType]avrotypemap.Ext
 	}
 	f.Close()
 	var runStdout bytes.Buffer
-	cmd := exec.Command("go", "run", prog)
+	cmd := exec.Command("go", "run", filepath.Base(prog))
 	cmd.Dir = *dirFlag
 	cmd.Stdout = &runStdout
 	cmd.Stderr = os.Stderr

--- a/cmd/avrogo/outputpath_test.go
+++ b/cmd/avrogo/outputpath_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var outputPathsTests = []struct {
+	testName    string
+	paths       []string
+	testFile    bool
+	expectError string
+	expect      map[string]string
+}{{
+	testName: "single-path",
+	paths:    []string{"foo.avsc"},
+	expect: map[string]string{
+		"foo.avsc": "foo_gen.go",
+	},
+}, {
+	testName: "several-paths",
+	paths:    []string{"foo.avsc", "bar.avsc"},
+	expect: map[string]string{
+		"foo.avsc": "foo_gen.go",
+		"bar.avsc": "bar_gen.go",
+	},
+}, {
+	testName: "ambiguous-paths",
+	paths:    []string{"alpha/bravo/x.avsc", "alpha/charlie/x.avsc"},
+	expect: map[string]string{
+		"alpha/bravo/x.avsc":   "bravo_x_gen.go",
+		"alpha/charlie/x.avsc": "charlie_x_gen.go",
+	},
+}, {
+	testName: "multiple-levels",
+	paths:    []string{"foo.avsc", "a/b/versions/v0.avsc", "a/c/versions/v0.avsc", "alpha/bravo/x.avsc", "alpha/charlie/x.avsc"},
+	expect: map[string]string{
+		"foo.avsc":             "foo_gen.go",
+		"a/b/versions/v0.avsc": "b_versions_v0_gen.go",
+		"a/c/versions/v0.avsc": "c_versions_v0_gen.go",
+		"alpha/bravo/x.avsc":   "bravo_x_gen.go",
+		"alpha/charlie/x.avsc": "charlie_x_gen.go",
+	},
+}, {
+	testName: "ambiguous-until-root",
+	paths:    []string{"/foo/bar.avsc", "foo/bar.avsc"},
+	expect: map[string]string{
+		"/foo/bar.avsc": "slash_foo_bar_gen.go",
+		"foo/bar.avsc":  "foo_bar_gen.go",
+	},
+}, {
+	testName: "ambiguous-until-start-of-relative",
+	paths:    []string{"foo/bar.avsc", "bar.avsc"},
+	expect: map[string]string{
+		"foo/bar.avsc": "foo_bar_gen.go",
+		"bar.avsc":     "bar_gen.go",
+	},
+}, {
+	testName: "duplicate paths",
+	paths:    []string{"x.avsc", "x.avsc"},
+	expect: map[string]string{
+		"x.avsc": "x_gen.go",
+	},
+}, {
+	testName:    "ambiguous-underscores",
+	paths:       []string{"x/y.avsc", "x_y.avsc", "z/y.avsc"},
+	expectError: "could not make unambiguous output files from input files",
+}, {
+	testName:    "ambiguous-ext",
+	paths:       []string{"x.json", "x.avsc"},
+	expectError: "could not make unambiguous output files from input files",
+}}
+
+func TestOutputPaths(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range outputPathsTests {
+		c.Run(test.testName, func(c *qt.C) {
+			result, err := outputPaths(test.paths, test.testFile)
+			if test.expectError != "" {
+				c.Check(result, qt.IsNil)
+				c.Assert(err, qt.ErrorMatches, test.expectError)
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, qt.DeepEquals, test.expect)
+		})
+	}
+}

--- a/cmd/avrogo/script_test.go
+++ b/cmd/avrogo/script_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestMain(m *testing.M) {
 	os.Exit(testscript.RunMain(m, map[string]func() int{
-		"go2avro": main1,
+		"avrogo": main1,
 	}))
 }
 
 func TestScript(t *testing.T) {
 	p := testscript.Params{
-		Dir: "testdata",
+		Dir: "testdata/script",
 	}
 	if err := gotooltest.Setup(&p); err != nil {
 		t.Fatal(err)

--- a/cmd/avrogo/testdata/script/non-existent-output-dir.txt
+++ b/cmd/avrogo/testdata/script/non-existent-output-dir.txt
@@ -1,0 +1,14 @@
+avrogo -p foo -d out/foo foo.avsc
+exists out/foo/foo_gen.go
+
+-- foo.avsc --
+{
+  "name": "R",
+  "type": "record",
+  "fields": [
+    {
+      "name": "A",
+      "type": "int"
+    }
+  ]
+}

--- a/cmd/avrogo/testdata/script/relativedir.txt
+++ b/cmd/avrogo/testdata/script/relativedir.txt
@@ -1,0 +1,39 @@
+# Note: we need to include an external type in the schema file
+# otherwise the previous issue won't be exposed (we won't
+# need to generate and run a Go file in the output directory).
+
+mkdir outdir
+avrogo -p foo -d outdir foo.avsc
+exists outdir/foo_gen.go
+
+-- foo.avsc --
+{
+  "name": "R",
+  "type": "record",
+  "fields": [
+    {
+      "name": "P",
+      "type": {
+        "name": "Point",
+        "go.package": "image",
+        "type": "record",
+        "fields": [
+          {
+            "name": "X",
+            "type": "long"
+          },
+          {
+            "name": "Y",
+            "type": "long"
+          }
+        ]
+      }
+    }
+  ]
+}
+-- go.mod --
+module example.com/foo/bar
+
+go 1.14
+
+require github.com/heetch/avro v0.2.1

--- a/cmd/go2avro/testdata/simple.txt
+++ b/cmd/go2avro/testdata/simple.txt
@@ -28,4 +28,4 @@ module example.com/foo/bar
 
 go 1.14
 
-require github.com/heetch/avro v0.0.0-20200318154341-de261c0e4b7f // indirect
+require github.com/heetch/avro v0.2.1


### PR DESCRIPTION
We fix an issue where a relative path passed as argument to the `-d`
flag would cause `avrogo` to report that the file doesn't exist,
and we also implement an algorithm to calculate unambiguous
output file names when passed several schema files with the same
base file name in almost all cases.

We also create the output directory if it doesn't already exist.