### PR TITLE
cmd/avrogo: better handling of IDL comments

### DIFF
--- a/cmd/avrogo/doccomment_test.go
+++ b/cmd/avrogo/doccomment_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var docTests = []struct {
+	testName string
+	val      interface{}
+	indent   string
+	expect   string
+}{{
+	testName: "simple-doc-string",
+	val:      docString("hello"),
+	indent:   "// ",
+	expect: `
+// hello
+`,
+}, {
+	testName: "not-a-doc-object",
+	val:      245,
+	indent:   "// ",
+	expect:   "",
+}, {
+	testName: "multi-line",
+	val: docString(`one line
+and another`),
+	indent: "// ",
+	expect: `
+// one line
+// and another
+`,
+}, {
+	testName: "empty-doc-string",
+	val:      docString(""),
+	indent:   "// ",
+	expect:   "",
+}, {
+	testName: "extra-white-space",
+	val:      docString(" \n  \thello\n \t "),
+	indent:   "// ",
+	expect: `
+// hello
+`,
+}, {
+	testName: "remove-stars",
+	val:      docString("* one two three\n\t\t * four five."),
+	indent:   "// ",
+	expect: `
+// one two three
+// four five.
+`,
+}, {
+	testName: "remove-stars-no-newlines",
+	val:      docString("* one two three"),
+	indent:   "// ",
+	expect: `
+// one two three
+`,
+}, {
+	testName: "remove-stars-less-spaces",
+	val:      docString("*one two three\n\t\t*four five\n\t\t*six seven\n\t\t*eight nine."),
+	indent:   "// ",
+	expect: `
+// one two three
+// four five
+// six seven
+// eight nine.
+`,
+}, {
+	testName: "different-indent",
+	val:      docString("hello"),
+	indent:   "!!",
+	expect: `
+!!hello
+`,
+}}
+
+func TestDoc(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range docTests {
+		c.Run(test.testName, func(c *qt.C) {
+			c.Assert(doc(test.indent, test.val), qt.Equals, test.expect)
+		})
+	}
+}
+
+type docString string
+
+func (d docString) Doc() string {
+	return string(d)
+}

--- a/cmd/avrogo/generate.go
+++ b/cmd/avrogo/generate.go
@@ -232,7 +232,7 @@ func isZeroDefault(x interface{}, t schema.AvroType) bool {
 			return ok && len(syms) > 0 && s == syms[0]
 		case *schema.FixedDefinition:
 			s, ok := x.(string)
-			return ok && s == strings.Repeat(string(0), def.SizeBytes())
+			return ok && s == strings.Repeat("\u0000", def.SizeBytes())
 		case *schema.RecordDefinition:
 			m, ok := x.(map[string]interface{})
 			if !ok {

--- a/cmd/avrogo/internal/generated_tests/cloudEvent/roundtrip_test.go
+++ b/cmd/avrogo/internal/generated_tests/cloudEvent/roundtrip_test.go
@@ -31,7 +31,8 @@ var tests = testutil.RoundTripTest{
                                             },
                                             {
                                                 "name": "source",
-                                                "type": "string"
+                                                "type": "string",
+                                                "doc": "* source holds the\n\t\t * source of the message."
                                             },
                                             {
                                                 "name": "specversion",
@@ -52,7 +53,8 @@ var tests = testutil.RoundTripTest{
                     },
                     {
                         "name": "other",
-                        "type": "string"
+                        "type": "string",
+                        "doc": "other documentation"
                     }
                 ],
                 "heetchmeta": {

--- a/cmd/avrogo/internal/generated_tests/cloudEvent/schema.avsc
+++ b/cmd/avrogo/internal/generated_tests/cloudEvent/schema.avsc
@@ -20,7 +20,8 @@
                                             },
                                             {
                                                 "name": "source",
-                                                "type": "string"
+                                                "type": "string",
+                                                "doc": "* source holds the\n\t\t * source of the message."
                                             },
                                             {
                                                 "name": "specversion",

--- a/cmd/avrogo/internal/generated_tests/cloudEvent/schema_gen.go
+++ b/cmd/avrogo/internal/generated_tests/cloudEvent/schema_gen.go
@@ -8,7 +8,10 @@ import (
 )
 
 type CloudEvent struct {
-	Id          string    `json:"id"`
+	Id string `json:"id"`
+
+	// source holds the
+	// source of the message.
 	Source      string    `json:"source"`
 	Specversion string    `json:"specversion"`
 	Time        time.Time `json:"time"`
@@ -17,7 +20,7 @@ type CloudEvent struct {
 // AvroRecord implements the avro.AvroRecord interface.
 func (CloudEvent) AvroRecord() avrotypegen.RecordInfo {
 	return avrotypegen.RecordInfo{
-		Schema: `{"fields":[{"name":"id","type":"string"},{"name":"source","type":"string"},{"name":"specversion","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"com.heetch.CloudEvent","type":"record"}`,
+		Schema: `{"fields":[{"name":"id","type":"string"},{"doc":"* source holds the\n\t\t * source of the message.","name":"source","type":"string"},{"name":"specversion","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"com.heetch.CloudEvent","type":"record"}`,
 		Required: []bool{
 			0: true,
 			1: true,
@@ -34,7 +37,7 @@ type Message struct {
 // AvroRecord implements the avro.AvroRecord interface.
 func (Message) AvroRecord() avrotypegen.RecordInfo {
 	return avrotypegen.RecordInfo{
-		Schema: `{"fields":[{"name":"Metadata","type":{"fields":[{"name":"CloudEvent","type":{"fields":[{"name":"id","type":"string"},{"name":"source","type":"string"},{"name":"specversion","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"CloudEvent","type":"record"}}],"name":"Metadata","type":"record"}}],"name":"com.heetch.Message","type":"record"}`,
+		Schema: `{"fields":[{"name":"Metadata","type":{"fields":[{"name":"CloudEvent","type":{"fields":[{"name":"id","type":"string"},{"doc":"* source holds the\n\t\t * source of the message.","name":"source","type":"string"},{"name":"specversion","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"CloudEvent","type":"record"}}],"name":"Metadata","type":"record"}}],"name":"com.heetch.Message","type":"record"}`,
 		Required: []bool{
 			0: true,
 		},
@@ -48,7 +51,7 @@ type Metadata struct {
 // AvroRecord implements the avro.AvroRecord interface.
 func (Metadata) AvroRecord() avrotypegen.RecordInfo {
 	return avrotypegen.RecordInfo{
-		Schema: `{"fields":[{"name":"CloudEvent","type":{"fields":[{"name":"id","type":"string"},{"name":"source","type":"string"},{"name":"specversion","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"CloudEvent","type":"record"}}],"name":"com.heetch.Metadata","type":"record"}`,
+		Schema: `{"fields":[{"name":"CloudEvent","type":{"fields":[{"name":"id","type":"string"},{"doc":"* source holds the\n\t\t * source of the message.","name":"source","type":"string"},{"name":"specversion","type":"string"},{"name":"time","type":{"logicalType":"timestamp-micros","type":"long"}}],"name":"CloudEvent","type":"record"}}],"name":"com.heetch.Metadata","type":"record"}`,
 		Required: []bool{
 			0: true,
 		},

--- a/cmd/avrogo/internal/generated_tests/largeRecord/roundtrip_test.go
+++ b/cmd/avrogo/internal/generated_tests/largeRecord/roundtrip_test.go
@@ -35,12 +35,12 @@ var tests = testutil.RoundTripTest{
                                                         "default": ""
                                                     }
                                                 ],
-                                                "namespace": "headerworks.datatype",
-                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014"
+                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014",
+                                                "namespace": "headerworks.datatype"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Unique identifier for the event used for de-duplication and tracing."
+                                        "doc": "Unique identifier for the event used for de-duplication and tracing.",
+                                        "default": null
                                     },
                                     {
                                         "name": "hostname",
@@ -48,8 +48,8 @@ var tests = testutil.RoundTripTest{
                                             "null",
                                             "string"
                                         ],
-                                        "default": null,
-                                        "doc": "Fully qualified name of the host that generated the event that generated the data."
+                                        "doc": "Fully qualified name of the host that generated the event that generated the data.",
+                                        "default": null
                                     },
                                     {
                                         "name": "trace",
@@ -65,23 +65,23 @@ var tests = testutil.RoundTripTest{
                                                             "null",
                                                             "headerworks.datatype.UUID0"
                                                         ],
-                                                        "default": null,
-                                                        "doc": "Trace Identifier"
+                                                        "doc": "Trace Identifier",
+                                                        "default": null
                                                     }
                                                 ],
                                                 "doc": "Trace0"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Trace information not redundant with this object"
+                                        "doc": "Trace information not redundant with this object",
+                                        "default": null
                                     }
                                 ],
-                                "namespace": "headerworks",
-                                "doc": "Common information related to the event which must be included in any clean event"
+                                "doc": "Common information related to the event which must be included in any clean event",
+                                "namespace": "headerworks"
                             }
                         ],
-                        "default": null,
-                        "doc": "Core data information required for any event"
+                        "doc": "Core data information required for any event",
+                        "default": null
                     },
                     {
                         "name": "body",
@@ -105,12 +105,12 @@ var tests = testutil.RoundTripTest{
                                                         "default": ""
                                                     }
                                                 ],
-                                                "namespace": "bodyworks.datatype",
-                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014"
+                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014",
+                                                "namespace": "bodyworks.datatype"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Unique identifier for the event used for de-duplication and tracing."
+                                        "doc": "Unique identifier for the event used for de-duplication and tracing.",
+                                        "default": null
                                     },
                                     {
                                         "name": "hostname",
@@ -118,8 +118,8 @@ var tests = testutil.RoundTripTest{
                                             "null",
                                             "string"
                                         ],
-                                        "default": null,
-                                        "doc": "Fully qualified name of the host that generated the event that generated the data."
+                                        "doc": "Fully qualified name of the host that generated the event that generated the data.",
+                                        "default": null
                                     },
                                     {
                                         "name": "trace",
@@ -135,27 +135,27 @@ var tests = testutil.RoundTripTest{
                                                             "null",
                                                             "headerworks.datatype.UUID0"
                                                         ],
-                                                        "default": null,
-                                                        "doc": "Trace Identifier"
+                                                        "doc": "Trace Identifier",
+                                                        "default": null
                                                     }
                                                 ],
                                                 "doc": "Trace1"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Trace information not redundant with this object"
+                                        "doc": "Trace information not redundant with this object",
+                                        "default": null
                                     }
                                 ],
-                                "namespace": "bodyworks",
-                                "doc": "Common information related to the event which must be included in any clean event"
+                                "doc": "Common information related to the event which must be included in any clean event",
+                                "namespace": "bodyworks"
                             }
                         ],
-                        "default": null,
-                        "doc": "Core data information required for any event"
+                        "doc": "Core data information required for any event",
+                        "default": null
                     }
                 ],
-                "namespace": "com.avro.test",
-                "doc": "GoGen test"
+                "doc": "GoGen test",
+                "namespace": "com.avro.test"
             }`,
 	GoType: new(Sample),
 	Subtests: []testutil.RoundTripSubtest{{

--- a/cmd/avrogo/internal/generated_tests/largeRecord/schema.avsc
+++ b/cmd/avrogo/internal/generated_tests/largeRecord/schema.avsc
@@ -24,12 +24,12 @@
                                                         "default": ""
                                                     }
                                                 ],
-                                                "namespace": "headerworks.datatype",
-                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014"
+                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014",
+                                                "namespace": "headerworks.datatype"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Unique identifier for the event used for de-duplication and tracing."
+                                        "doc": "Unique identifier for the event used for de-duplication and tracing.",
+                                        "default": null
                                     },
                                     {
                                         "name": "hostname",
@@ -37,8 +37,8 @@
                                             "null",
                                             "string"
                                         ],
-                                        "default": null,
-                                        "doc": "Fully qualified name of the host that generated the event that generated the data."
+                                        "doc": "Fully qualified name of the host that generated the event that generated the data.",
+                                        "default": null
                                     },
                                     {
                                         "name": "trace",
@@ -54,23 +54,23 @@
                                                             "null",
                                                             "headerworks.datatype.UUID0"
                                                         ],
-                                                        "default": null,
-                                                        "doc": "Trace Identifier"
+                                                        "doc": "Trace Identifier",
+                                                        "default": null
                                                     }
                                                 ],
                                                 "doc": "Trace0"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Trace information not redundant with this object"
+                                        "doc": "Trace information not redundant with this object",
+                                        "default": null
                                     }
                                 ],
-                                "namespace": "headerworks",
-                                "doc": "Common information related to the event which must be included in any clean event"
+                                "doc": "Common information related to the event which must be included in any clean event",
+                                "namespace": "headerworks"
                             }
                         ],
-                        "default": null,
-                        "doc": "Core data information required for any event"
+                        "doc": "Core data information required for any event",
+                        "default": null
                     },
                     {
                         "name": "body",
@@ -94,12 +94,12 @@
                                                         "default": ""
                                                     }
                                                 ],
-                                                "namespace": "bodyworks.datatype",
-                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014"
+                                                "doc": "A Universally Unique Identifier, in canonical form in lowercase. Example: de305d54-75b4-431b-adb2-eb6b9e546014",
+                                                "namespace": "bodyworks.datatype"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Unique identifier for the event used for de-duplication and tracing."
+                                        "doc": "Unique identifier for the event used for de-duplication and tracing.",
+                                        "default": null
                                     },
                                     {
                                         "name": "hostname",
@@ -107,8 +107,8 @@
                                             "null",
                                             "string"
                                         ],
-                                        "default": null,
-                                        "doc": "Fully qualified name of the host that generated the event that generated the data."
+                                        "doc": "Fully qualified name of the host that generated the event that generated the data.",
+                                        "default": null
                                     },
                                     {
                                         "name": "trace",
@@ -124,25 +124,25 @@
                                                             "null",
                                                             "headerworks.datatype.UUID0"
                                                         ],
-                                                        "default": null,
-                                                        "doc": "Trace Identifier"
+                                                        "doc": "Trace Identifier",
+                                                        "default": null
                                                     }
                                                 ],
                                                 "doc": "Trace1"
                                             }
                                         ],
-                                        "default": null,
-                                        "doc": "Trace information not redundant with this object"
+                                        "doc": "Trace information not redundant with this object",
+                                        "default": null
                                     }
                                 ],
-                                "namespace": "bodyworks",
-                                "doc": "Common information related to the event which must be included in any clean event"
+                                "doc": "Common information related to the event which must be included in any clean event",
+                                "namespace": "bodyworks"
                             }
                         ],
-                        "default": null,
-                        "doc": "Core data information required for any event"
+                        "doc": "Core data information required for any event",
+                        "default": null
                     }
                 ],
-                "namespace": "com.avro.test",
-                "doc": "GoGen test"
+                "doc": "GoGen test",
+                "namespace": "com.avro.test"
             }

--- a/cmd/avrogo/testdata/cloudevent.cue
+++ b/cmd/avrogo/testdata/cloudevent.cue
@@ -25,6 +25,7 @@ tests: cloudEvent: {
 							name: "id"
 							type: "string"
 						}, {
+							doc: "* source holds the\n\t\t * source of the message."
 							name: "source"
 							type: "string"
 						}, {
@@ -63,6 +64,7 @@ tests: cloudEvent: {
 							name: "id"
 							type: "string"
 						}, {
+							doc: "* source holds the\n\t\t * source of the message."
 							name: "source"
 							type: "string"
 						}, {


### PR DESCRIPTION
The IDL spec says:

> Comments that begin with /** are used as the documentation string for the type or field definition that follows the comment.

The idl2schemata tool takes that literally and includes all the comment
text including the leading `*`. This doesn't look nice when converted
to a Go doc comment, so remove the stars.