### PR TITLE
avro: fix canonicalization

### DIFF
--- a/avroregistry/registry_test.go
+++ b/avroregistry/registry_test.go
@@ -35,6 +35,19 @@ func TestRegister(t *testing.T) {
 	c.Assert(id1, qt.Equals, id)
 }
 
+func TestRegisterWithEmptyStruct(t *testing.T) {
+	c := qt.New(t)
+	defer c.Done()
+	r, subject := newTestRegistry(c)
+	type Empty struct{}
+	type R struct {
+		X Empty
+	}
+	ctx := context.Background()
+	_, err := r.Register(ctx, subject, schemaOf(nil, R{}))
+	c.Assert(err, qt.Equals, nil)
+}
+
 func TestSchemaCompatibility(t *testing.T) {
 	c := qt.New(t)
 	defer c.Done()

--- a/cmd/avrogo/internal/generated_tests/cloudEvent/roundtrip_test.go
+++ b/cmd/avrogo/internal/generated_tests/cloudEvent/roundtrip_test.go
@@ -53,8 +53,7 @@ var tests = testutil.RoundTripTest{
                     },
                     {
                         "name": "other",
-                        "type": "string",
-                        "doc": "other documentation"
+                        "type": "string"
                     }
                 ],
                 "heetchmeta": {

--- a/type_test.go
+++ b/type_test.go
@@ -239,6 +239,14 @@ var canonicalStringTests = []struct {
 	}]`,
 	out: `["int","string",{"name":"E","type":"enum","symbols":["a","b"]}]`,
 }, {
+	testName: "empty-record",
+	in: `{
+	"name": "R",
+	"type": "record",
+	"fields": []
+}`,
+	out: `{"name":"R","type":"record","fields":[]}`,
+}, {
 	testName: "out-of-bounds-opts",
 	in:       `"string"`,
 	out:      `"string"`,


### PR DESCRIPTION
We were omitting the `fields` member when there were
no fields rather than including an empty array.