### PR TITLE
Fix canonical form of schema for null as default

### DIFF
--- a/type.go
+++ b/type.go
@@ -94,18 +94,47 @@ type canonicalFields struct {
 	Items   interface{}        `json:"items,omitempty"`
 	Size    int                `json:"size,omitempty"`
 	Values  interface{}        `json:"values,omitempty"`
-	// The default field isn't mentioned in the specification, but is
-	// important to store in the registry, so we allow it to be
+	// The default field isn't mentioned in the specification, but
+	// it is important to store in the registry, so we allow it to be
 	// kept with the LeaveDefaults option to CanonicalString.
 	// TODO the Avro spec doesn't define canonicalization for
 	// numeric values, which could be an issue.
-	Default interface{} `json:"default,omitempty"`
+	// "default" is set via custom marshalling due to the fact null could be a
+	// default value and we can't use omitempty in this case.
+	DefaultValue interface{} `json:"-"`
+	HasDefault   bool        `json:"-"`
 	// Logical types aren't mentioned in the specification either,
 	// but they're important to maintain so that we can potentially
 	// guard against data corruption due to changed logical types.
 	LogicalType string `json:"logicalType,omitempty"`
 	Precision   int    `json:"precision,omitempty"`
 	Scale       int    `json:"scale,omitempty"`
+}
+
+// MarshalJSON implements json interface to print default null values if available
+func (cf *canonicalFields) MarshalJSON() ([]byte, error) {
+	// Alias set to avoid infinite loop and be less verbose
+	type alias canonicalFields
+	var v interface{}
+	v = &struct{ *alias }{alias: (*alias)(cf)}
+	if cf.HasDefault {
+		v = &struct {
+			*alias
+			Default interface{} `json:"default"`
+		}{
+			alias:   (*alias)(cf),
+			Default: cf.DefaultValue,
+		}
+	}
+	// Use encoder to disable escaping of HTML metacharacters.
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return []byte(strings.TrimSuffix(buf.String(), "\n")), nil
+
 }
 
 func (c *canonicalizer) canonicalValue(at schema.AvroType) interface{} {
@@ -205,7 +234,8 @@ func (c *canonicalizer) canonicalValue1(at schema.AvroType) interface{} {
 					Type: c.canonicalValue(f.Type()),
 				}
 				if f.HasDefault() && (c.opts&RetainDefaults) != 0 {
-					cfields[i].Default = f.Default()
+					cfields[i].DefaultValue = f.Default()
+					cfields[i].HasDefault = true
 				}
 			}
 			return cf

--- a/type_test.go
+++ b/type_test.go
@@ -199,7 +199,7 @@ var canonicalStringTests = []struct {
 }`,
 	out: `{"name":"com.example.R","type":"record","fields":[{"name":"a","type":{"name":"com.example.E","type":"enum","symbols":["a","b"]}},{"name":"b","type":{"name":"foo.F","type":"enum","symbols":["a","b"]}},{"name":"c","type":"com.example.E"}]}`,
 }, {
-	testName: "primitive_types",
+	testName: "primitive-types",
 	in: `{
 	"name": "R",
 	"type": "record",
@@ -238,6 +238,30 @@ var canonicalStringTests = []struct {
 		"symbols": ["a", "b"]
 	}]`,
 	out: `["int","string",{"name":"E","type":"enum","symbols":["a","b"]}]`,
+}, {
+	testName: "union-with-default",
+	opts:     avro.RetainDefaults,
+	in: `{"type": "record",
+              "name": "R",
+              "fields":[
+              {"name": "U",
+               "type": ["int","string"],
+               "default": 3
+              }]
+        }`,
+	out: `{"name":"R","type":"record","fields":[{"name":"U","type":["int","string"],"default":3}]}`,
+}, {
+	testName: "union-with-default-null",
+	opts:     avro.RetainDefaults,
+	in: `{"type": "record",
+              "name": "R",
+              "fields":[
+              {"name": "U",
+               "type": ["null","string"],
+               "default": null
+              }]
+        }`,
+	out: `{"name":"R","type":"record","fields":[{"name":"U","type":["null","string"],"default":null}]}`,
 }, {
 	testName: "empty-record",
 	in: `{


### PR DESCRIPTION
This was omitted in case of default being null. Typical use case for union types. A test case has been added to make sure it works.

Without this fix, the schema was registered using `avroregistry` package without default attribute in case of `"default": null`.