### PR TITLE
Use canonical schema in avrogo generated files

### DIFF
--- a/cmd/avrogo/generate.go
+++ b/cmd/avrogo/generate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/heetch/avro"
 	"io"
 	"regexp"
 	"sort"
@@ -102,7 +103,12 @@ func (gc *generateContext) RecordInfoLiteral(t *schema.RecordDefinition) (string
 	if err != nil {
 		panic(err)
 	}
-	fprintf(w, "Schema: %s,\n", quote(schemaStr))
+	schemaType, err := avro.ParseType(schemaStr)
+	if err != nil {
+		return "", err
+	}
+	canonical := schemaType.CanonicalString(avro.RetainDefaults | avro.RetainLogicalTypes)
+	fprintf(w, "Schema: %s,\n", quote(canonical))
 	doneRequired := false
 	for i, f := range t.Fields() {
 		if f.HasDefault() {


### PR DESCRIPTION
I tried to convert the schema that is written by `avrogo` into its canonical form, to see if that would fix an error related to schemas not being found. The error doesn't seem to be fixed, but this can be a foundation to work on later.

I'll leave the code here to be open for comments and suggestions.