### PR TITLE
Improve subject deletion error message

### DIFF
--- a/avroregistrytest/avroregistrytest.go
+++ b/avroregistrytest/avroregistrytest.go
@@ -45,7 +45,7 @@ func Register(ctx context.Context, t T, x interface{}, topic string) error {
 	t.Cleanup(func() {
 		err := registry.DeleteSubject(ctx, topic)
 		if err != nil {
-			t.Errorf("cannot delete subject: %w", err)
+			t.Errorf("cannot delete subject %v: %v", topic, err)
 		}
 	})
 


### PR DESCRIPTION
I got a subject deletion error because in a `main_test` I registered all topics and forgot that the `kafkatest` producer (from another repo) also registers the topic of the message it produces. So one topic was registered twice (no issue), and because of the `t.Cleanup` also cleaned up twice => First delete works, second one doesn't 💥  and with that the whole test is marked as failed.

Not knowing which topic caused the issue made debugging harder. So here I propose to include the topic in the error message. Also the `%w` was misused: It's only supported in `fmt.Errorf` for _creating a new error_, not in `t.Errorf`, which doesn't create a new error.

Old error: `cannot delete subject: %!w(*avroregistry.apiError=&{40401 Subject not found. 404})`
New error: `cannot delete subject foo.bar.v0: Avro registry error (code 40401; HTTP status 404): Subject not found`

P.S.: I think we could even check the deletion error and if it's a `NotFound` we can ignore it, but one step after another 🙂 