### PR TITLE
Add avroregistry.Schema

### DIFF
--- a/avroregistry/message.go
+++ b/avroregistry/message.go
@@ -44,12 +44,7 @@ func (r encodingRegistry) IDForSchema(ctx context.Context, schema *avro.Type) (i
 	}
 	req := r.r.newRequest(ctx, "POST", "/subjects/"+r.subject, bytes.NewReader(data))
 
-	var resp struct {
-		Subject string `json:"subject"`
-		ID      int64  `json:"id"`
-		Version int    `json:"version"`
-		Schema  string `json:"schema"`
-	}
+	var resp Schema
 	if err := r.r.doRequest(req, &resp); err != nil {
 		return 0, err
 	}

--- a/avroregistry/registry_test.go
+++ b/avroregistry/registry_test.go
@@ -69,11 +69,11 @@ func TestSchemaCompatibility(t *testing.T) {
 	}
 	names := new(avro.Names).RenameType(R1{}, "R")
 	_, err = r.Register(ctx, subject, schemaOf(names, R1{}))
-	c.Assert(err, qt.ErrorMatches, `Avro registry error \(HTTP status 409\): Schema being registered is incompatible with an earlier schema`)
+	c.Assert(err, qt.ErrorMatches, `Avro registry error \(HTTP status 409\): Schema being registered is incompatible with an earlier schema for subject "`+subject+`"`)
 
 	// Check that we can't rename the schema.
 	_, err = r.Register(ctx, subject, schemaOf(nil, R1{}))
-	c.Assert(err, qt.ErrorMatches, `Avro registry error \(HTTP status 409\): Schema being registered is incompatible with an earlier schema`)
+	c.Assert(err, qt.ErrorMatches, `Avro registry error \(HTTP status 409\): Schema being registered is incompatible with an earlier schema for subject "`+subject+`"`)
 
 	// Check that we can change the field to a compatible union.
 	type R2 struct {
@@ -90,7 +90,7 @@ func TestSchemaCompatibility(t *testing.T) {
 	}
 	names = new(avro.Names).RenameType(R3{}, "R")
 	_, err = r.Register(ctx, subject, schemaOf(names, R3{}))
-	c.Assert(err, qt.ErrorMatches, `Avro registry error \(HTTP status 409\): Schema being registered is incompatible with an earlier schema`)
+	c.Assert(err, qt.ErrorMatches, `Avro registry error \(HTTP status 409\): Schema being registered is incompatible with an earlier schema for subject "`+subject+`"`)
 }
 
 func TestSchemasRetainLogicalTypes(t *testing.T) {
@@ -508,13 +508,14 @@ func parseType(s string) *avro.Type {
 }
 
 // newTestRegistry returns a registry instance connected server
-// pointed by AVRO_REGISTRY_URL env var with a random subject to use.
+// pointed by KAFKA_REGISTRY_ADDR env var with a random subject to use.
 func newTestRegistry(c *qt.C) (*avroregistry.Registry, string) {
 	ctx := context.Background()
-	serverURL := os.Getenv("AVRO_REGISTRY_URL")
-	if serverURL == "" {
-		c.Skip("no AVRO_REGISTRY_URL configured")
+	serverAddr := os.Getenv("KAFKA_REGISTRY_ADDR")
+	if serverAddr == "" {
+		c.Skip("no KAFKA_REGISTRY_ADDR configured")
 	}
+	serverURL := "http://" + serverAddr
 	subject := randomString()
 	registry, err := avroregistry.New(avroregistry.Params{
 		ServerURL:     serverURL,


### PR DESCRIPTION
This PR implements `GET /subjects/{subject}/versions/{version}`.

See https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions-(versionId-%20version)
for details.

It also fixes registry tests to be run in CI and other minor fixes
after deprecating Go versions lower than 1.15.
