### PR TITLE
Add logicalType "duration-nanos"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ When the `avrogo` command generates Go datatypes from Avro schemas, it uses the 
   as `time.Time` type
 - `{"type": "string", "logicalType": "uuid"}` is represented as
   [github.com/google/uuid.UUID](https://pkg.go.dev/github.com/google/uuid#UUID) type.
+- `{"type": "long", "name": "duration-nanos"}` is represented as `time.Duration` type.
 
 If a definition has a `go.package` annotation the type from that package will be used instead of generating a Go type. The type must be compatible with the Avro schema (it may contain extra fields, but all fields in common must be compatible).
 

--- a/analyze.go
+++ b/analyze.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	timeType = reflect.TypeOf(time.Time{})
-	byteType = reflect.TypeOf(byte(0))
-	uuidType = reflect.TypeOf(gouuid.UUID{})
+	timeType     = reflect.TypeOf(time.Time{})
+	durationType = reflect.TypeOf(time.Duration(0))
+	byteType     = reflect.TypeOf(byte(0))
+	uuidType     = reflect.TypeOf(gouuid.UUID{})
 )
 
 type decodeProgram struct {
@@ -492,7 +493,7 @@ func canAssignVMType(operand int, dstType reflect.Type) bool {
 	case vm.Boolean:
 		return dstKind == reflect.Bool
 	case vm.Int, vm.Long:
-		return dstType == timeType || reflect.Int <= dstKind && dstKind <= reflect.Int64
+		return dstType == timeType || dstType == durationType || reflect.Int <= dstKind && dstKind <= reflect.Int64
 	case vm.Float, vm.Double:
 		return dstKind == reflect.Float64 || dstKind == reflect.Float32
 	case vm.Bytes:

--- a/cmd/avrogo/generate.go
+++ b/cmd/avrogo/generate.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	durationNanos   = "duration-nanos"
 	timestampMicros = "timestamp-micros"
 	timestampMillis = "timestamp-millis"
 	uuid            = "uuid"
@@ -476,11 +477,15 @@ func (gc *generateContext) GoTypeOf(t schema.AvroType) typeInfo {
 		// Note: Go int is at least 32 bits.
 		info.GoType = "int"
 	case *schema.LongField:
-		// TODO support timestampMillis. https://github.com/heetch/avro/issues/3
-		if logicalType(t) == timestampMicros {
+		switch logicalType(t) {
+		case timestampMicros:
+			// TODO support timestampMillis. https://github.com/heetch/avro/issues/3
 			info.GoType = "time.Time"
 			gc.addImport("time")
-		} else {
+		case durationNanos:
+			info.GoType = "time.Duration"
+			gc.addImport("time")
+		default:
 			info.GoType = "int64"
 		}
 	case *schema.FloatField:

--- a/cmd/avrogo/testdata/logicaltype.cue
+++ b/cmd/avrogo/testdata/logicaltype.cue
@@ -51,3 +51,20 @@ tests: invalidUUID: {
        outData: null
        expectError: unmarshal: "invalid UUID in Avro encoding: invalid UUID length: 12"
 }
+
+tests: durationNanos: {
+	inSchema: {
+		type: "record"
+		name: "R"
+		fields: [{
+			name: "D"
+			type: {
+				type:        "long"
+				logicalType: "duration-nanos"
+			}
+		}]
+	}
+	outSchema: inSchema
+	inData: D: 15000000000
+	outData: inData
+}

--- a/cue.mod/pkg/github.com/heetch/cue-schema/avro/schema.cue
+++ b/cue.mod/pkg/github.com/heetch/cue-schema/avro/schema.cue
@@ -91,7 +91,7 @@ LogicalType :: {
 	logicalType: string
 }
 
-LogicalType :: DecimalBytes | DecimalFixed | UUID | Date | *TimeMillis | *TimeMicros | TimestampMillis | TimestampMicros
+LogicalType :: DecimalBytes | DecimalFixed | UUID | Date | *TimeMillis | *TimeMicros | TimestampMillis | TimestampMicros | DurationNanos
 
 DecimalBytes :: {
 	type:        "bytes"
@@ -138,4 +138,9 @@ TimestampMillis :: {
 TimestampMicros :: {
 	type:        "long"
 	logicalType: "timestamp-micros"
+}
+
+DurationNanos :: {
+	type:        "long"
+	logicalType: "duration-nanos"
 }

--- a/decode.go
+++ b/decode.go
@@ -149,12 +149,16 @@ func (d *decoder) eval(target reflect.Value) {
 				// need more information from the VM to be able to
 				// do that, so support only timestamp-micros for now.
 				// See https://github.com/heetch/avro/issues/3
-				if target.Type() == timeType {
+				switch target.Type() {
+				case timeType:
 					// timestamp-micros
 					target.Set(reflect.ValueOf(time.Unix(frame.Int/1e6, frame.Int%1e6*1e3)))
-					break
+				case durationType:
+					// duration-nanos
+					target.Set(reflect.ValueOf(time.Duration(frame.Int)))
+				default:
+					target.SetInt(frame.Int)
 				}
-				target.SetInt(frame.Int)
 			case vm.Int:
 				target.SetInt(frame.Int)
 			case vm.Float, vm.Double:


### PR DESCRIPTION
This PR extends support for `time.Duration` converting from/to Avro using a
logical type that we have defined `duration-nanos` as @rogpeppe suggested in
https://github.com/heetch/avro/issues/3#issuecomment-578120531.

`time.Duration` <=> `{"type": {"type": "long", "logicalType": "duration-nanos"}}}`
