### PR TITLE
Allow UUID empty string decoding as empty UUID object

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -176,11 +176,15 @@ func (d *decoder) eval(target reflect.Value) {
 				}
 			case vm.String:
 				if target.Type() == uuidType {
+					if frame.String == "" {
+						// We produce the empty string "" when encoding zero UUID value,
+						// so allow it when decoding too.
+						target.Set(reflect.ValueOf(gouuid.UUID{}))
+						break
+					}
 					val, err := gouuid.Parse(frame.String)
 					if err != nil {
-						if len(frame.String) != 0 {
-							d.error(fmt.Errorf("invalid UUID in Avro encoding: %w", err))
-						} // We allow written "" on encoding zero UUID value, so we do in decoding part
+						d.error(fmt.Errorf("invalid UUID in Avro encoding: %w", err))
 					} else {
 						target.Set(reflect.ValueOf(val))
 					}

--- a/decode.go
+++ b/decode.go
@@ -178,7 +178,9 @@ func (d *decoder) eval(target reflect.Value) {
 				if target.Type() == uuidType {
 					val, err := gouuid.Parse(frame.String)
 					if err != nil {
-						d.error(fmt.Errorf("invalid UUID in Avro encoding: %w", err))
+						if len(frame.String) != 0 {
+							d.error(fmt.Errorf("invalid UUID in Avro encoding: %w", err))
+						} // We allow written "" on encoding zero UUID value, so we do in decoding part
 					} else {
 						target.Set(reflect.ValueOf(val))
 					}

--- a/gotype_test.go
+++ b/gotype_test.go
@@ -247,6 +247,11 @@ func TestGoTypeWithUUID(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			c.Assert(x, qt.DeepEquals, R{})
 		}
+
+		var x R
+		_, err = avro.Unmarshal(data, &x, wType)
+		c.Assert(err, qt.IsNil)
+		c.Assert(x, qt.DeepEquals, R{})
 	})
 
 }


### PR DESCRIPTION
As we do in UUID encoding https://github.com/heetch/avro/blob/master/encode.go#L278-L279.

For the cases, we are encoding zero UUID, we sending to the wire "" 
so the decoding should behave the same way to hold a zero value in this case too.
