### PR TITLE
Add support for standard Go initialisms to avrogo

### DIFF
--- a/cmd/avrogo/generate_test.go
+++ b/cmd/avrogo/generate_test.go
@@ -138,3 +138,66 @@ func TestGoName(t *testing.T) {
 		})
 	}
 }
+
+func TestSymbolName(t *testing.T) {
+	enumDef := avro.NewEnumDefinition(avro.QualifiedName{Namespace: "ns", Name: "name"}, nil, nil, "", "", nil)
+
+	var testcases = []struct {
+		testName         string
+		goInitialisms    bool
+		extraInitialisms string
+		symbol           string
+		goName           string
+	}{
+		{
+			testName:      "default naming",
+			goInitialisms: false,
+			symbol:        "OPTION_ONE",
+			goName:        "NameOption_one",
+		},
+		{
+			testName:      "Go initialisms",
+			goInitialisms: true,
+			symbol:        "OPTION_ONE",
+			goName:        "NameOptionOne",
+		},
+		{
+			testName:      "default naming with ID",
+			goInitialisms: false,
+			symbol:        "OPTION_ID",
+			goName:        "NameOption_id",
+		},
+		{
+			testName:      "Go initialisms with ID",
+			goInitialisms: true,
+			symbol:        "OPTION_ID",
+			goName:        "NameOptionID",
+		},
+		{
+			testName:      "Go initialisms without extra initialisms",
+			goInitialisms: true,
+			symbol:        "OPTION_TWO",
+			goName:        "NameOptionTwo",
+		},
+		{
+			testName:         "Go initialisms with extra initialisms",
+			goInitialisms:    true,
+			extraInitialisms: "ONE,TWO,THREE",
+			symbol:           "OPTION_TWO",
+			goName:           "NameOptionTWO",
+		},
+	}
+
+	c := qt.New(t)
+
+	for _, test := range testcases {
+		c.Run(test.testName, func(c *qt.C) {
+			goInitalismFlag = &test.goInitialisms
+			extraInitialismsFlag = &test.extraInitialisms
+			gc := generateContext{caser: getCaser()}
+
+			gotName := symbolName(&gc, enumDef, test.symbol)
+			c.Assert(gotName, qt.Equals, test.goName)
+		})
+	}
+}

--- a/cmd/avrogo/generate_test.go
+++ b/cmd/avrogo/generate_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/actgardner/gogen-avro/v10/parser"
 	"github.com/actgardner/gogen-avro/v10/schema"
-	"testing"
 
 	avro "github.com/actgardner/gogen-avro/v10/schema"
 	qt "github.com/frankban/quicktest"
@@ -72,6 +73,68 @@ func TestShouldImportAvroTypeGen(t *testing.T) {
 		c.Run(test.testName, func(c *qt.C) {
 			value := shouldImportAvroTypeGen(test.namespace, test.definitions)
 			c.Assert(value, qt.Equals, test.shouldImportAvroTypeGen)
+		})
+	}
+}
+
+func TestGoName(t *testing.T) {
+	var testcases = []struct {
+		testName         string
+		goInitialisms    bool
+		extraInitialisms string
+		avroName         string
+		goName           string
+	}{
+		{
+			testName:      "default naming",
+			goInitialisms: false,
+			avroName:      "user.first_name",
+			goName:        "First_name",
+		},
+		{
+			testName:      "Go initialisms",
+			goInitialisms: true,
+			avroName:      "user.first_name",
+			goName:        "FirstName",
+		},
+		{
+			testName:      "default naming with ID",
+			goInitialisms: false,
+			avroName:      "user.user_id",
+			goName:        "User_id",
+		},
+		{
+			testName:      "Go initialisms with ID",
+			goInitialisms: true,
+			avroName:      "user.user_id",
+			goName:        "UserID",
+		},
+		{
+			testName:      "Go initialisms without extra initialisms",
+			goInitialisms: true,
+			avroName:      "power.power_mw",
+			goName:        "PowerMw",
+		},
+		{
+			testName:         "Go initialisms with extra initialisms",
+			goInitialisms:    true,
+			extraInitialisms: "KW,MW,GW",
+			avroName:         "power.power_mw",
+			goName:           "PowerMW",
+		},
+	}
+
+	c := qt.New(t)
+
+	for _, test := range testcases {
+		c.Run(test.testName, func(c *qt.C) {
+			goInitalismFlag = &test.goInitialisms
+			extraInitialismsFlag = &test.extraInitialisms
+			gc := generateContext{caser: getCaser()}
+
+			gotName, err := gc.goName(test.avroName)
+			c.Assert(err, qt.IsNil)
+			c.Assert(gotName, qt.Equals, test.goName)
 		})
 	}
 }

--- a/cmd/avrogo/template.go
+++ b/cmd/avrogo/template.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"go/token"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/actgardner/gogen-avro/v10/parser"
 	"github.com/actgardner/gogen-avro/v10/schema"
@@ -27,9 +28,11 @@ var templateFuncs = template.FuncMap{
 	"isExportedGoIdentifier": isExportedGoIdentifier,
 	"defName":                defName,
 	"symbolName":             symbolName,
-	"goName":                 goName,
-	"indent":                 indent,
-	"doc":                    doc,
+	"goName": func(gc *generateContext, name string) (string, error) {
+		return gc.goName(name)
+	},
+	"indent": indent,
+	"doc":    doc,
 	"import": func(gc *generateContext, pkg string) string {
 		gc.addImport(pkg)
 		return ""
@@ -73,7 +76,7 @@ var bodyTemplate = newTemplate(`
 			«- if isExportedGoIdentifier .Name»
 				«- .Name» «$type.GoType»
 			«- else»
-				«- goName .Name» «$type.GoType» ` + "`" + `json:«printf "%q" .Name»` + "`" + `
+				«- goName $.Ctx .Name» «$type.GoType» ` + "`" + `json:«printf "%q" .Name»` + "`" + `
 			«- end»
 		«end»
 		}

--- a/cmd/avrogo/template.go
+++ b/cmd/avrogo/template.go
@@ -8,9 +8,6 @@ import (
 	"strings"
 	"text/template"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	"github.com/actgardner/gogen-avro/v10/parser"
 	"github.com/actgardner/gogen-avro/v10/schema"
 )
@@ -92,7 +89,7 @@ var bodyTemplate = newTemplate(`
 		type «defName .» int
 		const (
 		«- range $i, $sym := .Symbols»
-		«symbolName $def $sym»«if eq $i 0» «defName $def» = iota«end»
+		«symbolName $.Ctx $def $sym»«if eq $i 0» «defName $def» = iota«end»
 		«- end»
 		)
 
@@ -144,8 +141,8 @@ func defName(def schema.Definition) string {
 	return goTypeForDefinition(def).Name
 }
 
-func symbolName(e *schema.EnumDefinition, symbol string) string {
-	return defName(e) + cases.Title(language.Und).String(symbol)
+func symbolName(gc *generateContext, e *schema.EnumDefinition, symbol string) string {
+	return defName(e) + gc.caser(symbol)
 }
 
 func quote(s string) string {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/actgardner/gogen-avro/v10 v10.2.1
+	github.com/ettle/strcase v0.2.0
 	github.com/frankban/quicktest v1.14.0
 	github.com/google/uuid v1.3.0
 	github.com/kr/pretty v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/actgardner/gogen-avro/v10 v10.2.1 h1:z3pOGblRjAJCYpkIJ8CmbMJdksi4rAha
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
+github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=


### PR DESCRIPTION
Fixes #126 

This PR adds support for generating idiomatic names with `avrogo`.

There is no change in behavior unless new flags are used:
- `-goinitialisms` turns on the new behaviour using the standard set of Go initialisms
- `-extrainitialisms` is an optional comma separated list of extra Go initialisms

Note to reviewers:
The style/structure of this repo is different to what I'm familiar with. Please let me know if anything is not following the existing conventions and I will update.