### PR TITLE
Fix Union Generation for map[string]interface{} in Avro Schemas

### DIFF
--- a/cmd/avrogo/generate.go
+++ b/cmd/avrogo/generate.go
@@ -192,8 +192,11 @@ func canOmitUnionInfo(u typeInfo) bool {
 	// Check that either there's no union or the union is ["null", T]
 	// (the default union type for a pointer) and the Go type is also
 	// a pointer, meaning the avro package can infer that it's a
-	// pointer union.
-	return len(u.Union) == 0 || (len(u.Union) == 2 && u.Union[0].GoType == nullType && u.GoType[0] == '*')
+	// pointer union.	
+	// If the union is ["null", map[string]T] then we can't omit the union
+	// Example: mapTest *map[string]interface{} `json:"mapTest"` will omit the union without this check for map
+	return len(u.Union) == 0 || (len(u.Union) == 2 && u.Union[0].GoType == nullType && u.GoType[0] == '*' && len(u.GoType) > 3 && u.GoType[:4] != "*map")
+
 }
 
 func writeUnionInfo(w io.Writer, info typeInfo) {


### PR DESCRIPTION
The current implementation of the avrogo code generator incorrectly omits union information for fields defined as map[string]interface{} in Avro schemas. This occurs specifically in cases where the union type is ["null", map[string]T]. The omission of this union information leads to incorrect code generation, not reflecting the intended schema's flexibility and complexity.

Example of Issue:
A field defined as mapTest *map[string]interface{} 'json:"mapTest"' in the Avro schema incorrectly omits the necessary union type information in the generated Go code.

Solution:
This pull request introduces a fix in the union type generation logic within the writeUnionInfo function. It specifically addresses the handling of map[string]interface{} fields to ensure the proper inclusion of union type information.

The fix involves updating the logic to recognize and correctly handle the ["null", map[string]T] union case, ensuring that it's not omitted during code generation. This change allows the generated Go code to accurately represent the Avro schema's structure and the intended flexibility of the map[string]interface{} field.