### PR TITLE
BCN-458 handle specific decoding error when schema registry unavailable

### DIFF
--- a/avroregistry/errors.go
+++ b/avroregistry/errors.go
@@ -1,0 +1,15 @@
+package avroregistry
+
+import (
+	"fmt"
+)
+
+// UnavailableError reports an error when the schema registry is unavailable.
+type UnavailableError struct {
+	Cause error
+}
+
+// Error implements the error interface.
+func (m *UnavailableError) Error() string {
+	return fmt.Sprintf("schema registry unavailability caused by: %v", m.Cause)
+}

--- a/avroregistry/errors.go
+++ b/avroregistry/errors.go
@@ -13,3 +13,8 @@ type UnavailableError struct {
 func (m *UnavailableError) Error() string {
 	return fmt.Sprintf("schema registry unavailability caused by: %v", m.Cause)
 }
+
+// Unwrap unwraps and return Cause error. It is needed to properly handle %w usage in fmt.Errorf cases.
+func (e *UnavailableError) Unwrap() error {
+	return e.Cause
+}

--- a/avroregistry/errors.go
+++ b/avroregistry/errors.go
@@ -14,7 +14,7 @@ func (m *UnavailableError) Error() string {
 	return fmt.Sprintf("schema registry unavailability caused by: %v", m.Cause)
 }
 
-// Unwrap unwraps and return Cause error. It is needed to properly handle %w usage in fmt.Errorf cases.
+// Unwrap unwraps and return Cause error. It is needed to properly handle and compare errors.
 func (e *UnavailableError) Unwrap() error {
 	return e.Cause
 }

--- a/avroregistry/errors_test.go
+++ b/avroregistry/errors_test.go
@@ -1,0 +1,34 @@
+package avroregistry_test
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/heetch/avro/avroregistry"
+)
+
+func TestUnavailableError_Unwrap(t *testing.T) {
+	c := qt.New(t)
+	var ErrExpect = errors.New("error")
+
+	err := &avroregistry.UnavailableError{
+		Cause: ErrExpect,
+	}
+
+	c.Assert(errors.Is(err, ErrExpect), qt.IsTrue)
+
+	var newErr *avroregistry.UnavailableError
+	c.Assert(errors.As(err, &newErr), qt.IsTrue)
+}
+
+func TestUnavailableError_Error(t *testing.T) {
+	c := qt.New(t)
+
+	err := &avroregistry.UnavailableError{
+		Cause: errors.New("ECONNREFUSED"),
+	}
+
+	c.Assert(err.Error(), qt.Equals, "schema registry unavailability caused by: ECONNREFUSED")
+}

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -210,6 +210,12 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			} else {
 				return apiErr
 			}
+		} else {
+			// some 5XX response body cannot be decoded
+			// hence an *apiError is not returned
+			if resp.StatusCode/100 == 5 {
+				err = &UnavailableError{err}
+			}
 		}
 
 		if !attempt.More() {

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -190,7 +190,7 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			if !attempt.More() || !isTemporaryError(err) {
-				return err
+				return &UnavailableError{err}
 			}
 			continue
 		}
@@ -201,7 +201,7 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 		if !attempt.More() {
 			return err
 		}
-		if err, ok := err.(*apiError); ok && err.StatusCode/100 != 5 {
+		if err, ok := err.(*apiError); ok && err.StatusCode != http.StatusInternalServerError {
 			// It's not a 5xx error. We want to retry on 5xx
 			// errors, because the Confluent Avro registry
 			// can occasionally return them as a matter of

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -199,7 +199,7 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			return nil
 		}
 		if !attempt.More() {
-			return err
+			return &UnavailableError{err}
 		}
 		if err, ok := err.(*apiError); ok && err.StatusCode != http.StatusInternalServerError {
 			// It's not a 5xx error. We want to retry on 5xx
@@ -208,6 +208,9 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			// course (and there could also be an
 			// unavailable service that we're reaching
 			// through a proxy).
+			if !attempt.More() {
+				return &UnavailableError{err}
+			}
 			return err
 		}
 	}

--- a/avroregistry/registry.go
+++ b/avroregistry/registry.go
@@ -206,9 +206,9 @@ func (r *Registry) doRequest(req *http.Request, result interface{}) error {
 			// unavailable service that we're reaching
 			// through a proxy).
 			if apiErr.StatusCode/100 == 5 {
-				return apiErr
-			} else {
 				err = &UnavailableError{apiErr}
+			} else {
+				return apiErr
 			}
 		}
 

--- a/avroregistry/registry_test.go
+++ b/avroregistry/registry_test.go
@@ -340,7 +340,7 @@ func TestRetryOn500(t *testing.T) {
 	// an error.
 	failCount = 5
 	err = registry.SetCompatibility(context.Background(), "x", avro.BackwardTransitive)
-	c.Assert(err, qt.ErrorMatches, `Avro registry error \(code 50001; HTTP status 500\): Failed to update compatibility level`)
+	c.Assert(err, qt.ErrorMatches, `schema registry unavailability caused by: Avro registry error \(code 50001; HTTP status 500\): Failed to update compatibility level`)
 }
 
 func TestNoRetryOnNon5XXStatus(t *testing.T) {
@@ -392,7 +392,7 @@ func TestUnavailableError(t *testing.T) {
 	})
 	c.Assert(err, qt.Equals, nil)
 	err = registry.SetCompatibility(context.Background(), "x", avro.BackwardTransitive)
-	c.Assert(err, qt.ErrorMatches, `cannot unmarshal JSON error response from .*/config/x: unexpected content type text/html; want application/json; content: 502 Proxy Error; Proxy Error; The whole world is bogus`)
+	c.Assert(err, qt.ErrorMatches, `schema registry unavailability caused by: cannot unmarshal JSON error response from .*/config/x: unexpected content type text/html; want application/json; content: 502 Proxy Error; Proxy Error; The whole world is bogus`)
 }
 
 var schemaEquivalenceTests = []struct {

--- a/singledecoder.go
+++ b/singledecoder.go
@@ -92,7 +92,7 @@ func (c *SingleDecoder) Unmarshal(ctx context.Context, data []byte, x interface{
 	}
 	prog, err := c.getProgram(ctx, vt, wID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot unmarshal: %v", err)
+		return nil, fmt.Errorf("cannot unmarshal: %w", err)
 	}
 	return unmarshal(nil, body, prog, v)
 }


### PR DESCRIPTION
Return a specific error that can be used to detect when the schema registry is unavailable. This means that, for example, number one can retry indefinitely in case such an error is encountered so as not to skip messages when consuming but otherwise respect a limited retry mechanism that might be in place. 

Instead of trying to check all the net.Error, url.Error or syscall.ECONNREFUSED, the logic has simply been reduced to "in case there is an error during performing the request and we have no more retries left then the registry is not available". This means that, even if we have consecutive timeouts that exceed the retry limit for operations will be considered as the schema registry is not available.