### PR TITLE
Update generate.go

### DIFF
--- a/cmd/avrogo/generate.go
+++ b/cmd/avrogo/generate.go
@@ -29,10 +29,7 @@ const nullType = "avrotypegen.Null"
 // schema.RecordDefinition by looking at their match within given parsed namespace
 func shouldImportAvroTypeGen(namespace *parser.Namespace, definitions []schema.QualifiedName) bool {
 	for _, def := range namespace.Definitions {
-		defToGenerateIdx := sort.Search(len(definitions), func(i int) bool {
-			return definitions[i].Name == def.AvroName().Name
-		})
-		if defToGenerateIdx < len(definitions) && def.AvroName().Name == definitions[defToGenerateIdx].Name {
+		if indexOf(definitions, def.AvroName().Name) > -1 {
 			if _, ok := def.(*schema.RecordDefinition); ok {
 				return true
 			}
@@ -42,6 +39,17 @@ func shouldImportAvroTypeGen(namespace *parser.Namespace, definitions []schema.Q
 		}
 	}
 	return false
+}
+
+func indexOf(definitions []schema.QualifiedName, avroName string) int {
+	found := -1
+	for i := 0; i < len(definitions); i++ {
+		if definitions[i].Name == avroName {
+			found = i
+			break
+		}
+	}
+	return found
 }
 
 func generate(w io.Writer, pkg string, ns *parser.Namespace, definitions []schema.QualifiedName) error {


### PR DESCRIPTION
The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next. Therefore, iterating through the `namespace.Definitions` map may sometimes not work with the `sort.Search()` function. This tweak seems to be much simpler to understand and makes more sense for the purpose of the `shouldImportAvroTypeGen()` function.

Fix to the problem reported in this issue: https://github.com/heetch/avro/issues/130